### PR TITLE
feat: Add lfsrs custom-transfer-agent type

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -496,10 +496,13 @@ where
                 });
 
                 let objects = future::try_join_all(objects).await?;
-                let response = lfs::BatchResponse {
-                    transfer: Some(lfs::Transfer::Basic),
-                    objects,
-                };
+                let mut transfer = Some(lfs::Transfer::Basic);
+                if let Some(transfers) = val.transfers {
+                    if transfers.contains(&lfs::Transfer::LfsRs) {
+                        transfer = Some(lfs::Transfer::LfsRs)
+                    }
+                }
+                let response = lfs::BatchResponse { transfer, objects };
 
                 Ok(Response::builder()
                     .status(StatusCode::OK)

--- a/src/lfs.rs
+++ b/src/lfs.rs
@@ -33,11 +33,12 @@ pub enum Operation {
 }
 
 /// A transfer adaptor.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Transfer {
     /// Basic transfer adapter.
     Basic,
+    LfsRs,
 
     LfsStandaloneFile,
 


### PR DESCRIPTION
This type does nothing different, but it's used to prevent the default basic transfer adapter from being used by the client.