### PR TITLE
chore: merge together updates and fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          toolchain: nightly
 
       - name: Run cargo fmt
         uses: actions-rust-lang/rustfmt@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -198,7 +198,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -209,8 +209,14 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -238,8 +244,8 @@ dependencies = [
  "bytes",
  "fastrand 1.9.0",
  "hex",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "ring 0.16.20",
  "time",
  "tokio",
@@ -271,7 +277,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "aws-types",
- "http",
+ "http 0.2.12",
  "regex",
  "tracing",
 ]
@@ -287,8 +293,8 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "lazy_static",
  "percent-encoding",
  "pin-project-lite",
@@ -314,7 +320,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand 1.9.0",
- "http",
+ "http 0.2.12",
  "regex",
  "tokio-stream",
  "tower",
@@ -339,7 +345,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http",
+ "http 0.2.12",
  "regex",
  "tokio-stream",
  "tower",
@@ -366,7 +372,7 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "http",
+ "http 0.2.12",
  "regex",
  "tower",
  "tracing",
@@ -382,7 +388,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-http",
  "aws-types",
- "http",
+ "http 0.2.12",
  "tracing",
 ]
 
@@ -396,7 +402,7 @@ dependencies = [
  "form_urlencoded",
  "hex",
  "hmac 0.12.1",
- "http",
+ "http 0.2.12",
  "once_cell",
  "percent-encoding",
  "regex",
@@ -429,13 +435,13 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand 1.9.0",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "hyper-rustls",
  "lazy_static",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.9",
  "tokio",
  "tower",
  "tracing",
@@ -451,9 +457,9 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "futures-core",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -472,8 +478,8 @@ dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "pin-project-lite",
  "tower",
  "tracing",
@@ -531,25 +537,24 @@ dependencies = [
  "aws-smithy-client",
  "aws-smithy-http",
  "aws-smithy-types",
- "http",
+ "http 0.2.12",
  "rustc_version",
  "tracing",
 ]
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "itoa",
  "matchit",
  "memchr",
@@ -566,17 +571,20 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -623,6 +631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,12 +654,6 @@ checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -767,7 +775,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -822,10 +830,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
+name = "core-foundation"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -846,15 +864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,25 +881,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -931,7 +927,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1144,7 +1140,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1222,6 +1218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,7 +1234,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.3.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.2.0",
  "indexmap 2.3.0",
  "slab",
  "tokio",
@@ -1305,13 +1326,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.2.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1325,7 +1380,7 @@ dependencies = [
  "async-channel",
  "base64 0.13.1",
  "futures-lite",
- "http",
+ "http 0.2.12",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -1379,9 +1434,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1394,30 +1449,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.20.9",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.5.1",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
 ]
 
 [[package]]
@@ -1427,10 +1504,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.30",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "hyper 1.5.1",
+ "pin-project-lite",
+ "socket2 0.5.7",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1576,17 +1672,21 @@ dependencies = [
  "futures",
  "generic-array",
  "hex",
- "http",
+ "http 0.2.12",
  "human-size",
  "humansize",
  "humantime",
- "hyper",
+ "hyper 0.14.30",
  "hyper-tls",
  "linked-hash-map",
  "log",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-http",
  "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
  "parking_lot",
  "pretty_env_logger",
  "rand 0.8.5",
@@ -1604,6 +1704,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
@@ -1629,7 +1730,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "libc",
 ]
 
@@ -1751,7 +1852,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1837,7 +1938,7 @@ version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1854,7 +1955,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1887,96 +1988,125 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.19.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5feffc321035ad94088a7e5333abb4d84a8726e54a802e736ce9dd7237e85b"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.8.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a819b71d6530c4297b49b3cae2939ab3a8cc1b9f382826a1bc29dd0ca3864906"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
- "hyper",
- "opentelemetry_api",
- "tokio",
+ "http 1.2.0",
+ "opentelemetry",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.12.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
- "futures",
- "futures-util",
- "http",
+ "futures-core",
+ "http 1.2.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
+ "opentelemetry_sdk",
  "prost",
  "thiserror",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.2.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
- "futures",
- "futures-util",
  "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
 ]
 
 [[package]]
-name = "opentelemetry_api"
-version = "0.19.0"
+name = "opentelemetry-semantic-conventions"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8a298402aa5c260be90d10dc54b5a7d4e1025c354848f8e2c976d761351049"
 dependencies = [
- "fnv",
- "futures-channel",
+ "async-trait",
+ "chrono",
  "futures-util",
- "indexmap 1.9.3",
- "once_cell",
- "pin-project-lite",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "ordered-float",
+ "serde",
+ "serde_json",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.19.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
- "dashmap",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "once_cell",
- "opentelemetry_api",
+ "glob",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.8.5",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65ee1f9701bf938026630b455d5315f490640234259037edb259798b3bcf85e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2053,7 +2183,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -2110,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2120,15 +2250,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2238,7 +2368,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2343,8 +2473,8 @@ dependencies = [
  "bytes",
  "crc32fast",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "hyper-rustls",
  "lazy_static",
  "log",
@@ -2367,7 +2497,7 @@ dependencies = [
  "chrono",
  "dirs-next",
  "futures",
- "hyper",
+ "hyper 0.14.30",
  "serde",
  "serde_json",
  "shlex",
@@ -2401,8 +2531,8 @@ dependencies = [
  "futures",
  "hex",
  "hmac 0.11.0",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "log",
  "md-5",
  "percent-encoding",
@@ -2450,7 +2580,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2470,15 +2600,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.0.1",
 ]
 
 [[package]]
@@ -2488,6 +2645,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2533,8 +2716,21 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2542,9 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2573,7 +2769,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -2739,20 +2935,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2767,9 +2952,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -2809,7 +2994,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -2886,16 +3071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,7 +3078,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -2922,16 +3097,26 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.9",
  "tokio",
  "webpki",
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.15"
+name = "tokio-rustls"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+dependencies = [
+ "rustls 0.23.20",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2991,37 +3176,35 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.22.1",
  "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.1",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
- "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-native-certs 0.8.1",
+ "rustls-pemfile 2.2.0",
+ "socket2 0.5.7",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.1",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -3076,7 +3259,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -3087,27 +3270,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -3123,16 +3285,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.19.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a39dcf9bfc1742fa4d6215253b33a6e474be78275884c216fc2a06267b3600"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.4",
+ "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -3162,7 +3328,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -3325,7 +3491,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3347,7 +3513,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3363,6 +3529,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3522,7 +3698,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "http-types",
- "hyper",
+ "hyper 0.14.30",
  "log",
  "once_cell",
  "regex",
@@ -3570,7 +3746,7 @@ checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -3581,7 +3757,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,30 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy 0.7.35",
-]
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
@@ -40,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -61,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -76,36 +64,37 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -113,6 +102,12 @@ name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "askama"
@@ -169,17 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -220,15 +204,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.10"
+version = "1.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
+checksum = "9f40e82e858e02445402906e454a73e244c7f501fcae198977585946c48e8697"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -237,13 +221,13 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.60.7",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand",
  "hex",
  "http 0.2.12",
  "ring",
@@ -268,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.4"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ac934720fbb46206292d2c75b57e67acfc56fe7dfd34fb9a02334af08409ea"
+checksum = "bee7643696e7fdd74c10f9eb42848a87fe469d35eae9c3323f80aa98f350baac"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -282,7 +266,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
  "once_cell",
@@ -294,21 +278,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.55.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18e18b3cf6b75c1fcb15e677f6dbd2a6d8dfe4d168e0a36721f7a6167c6c829"
+checksum = "822deb729d56924c4c97427cb7fbe2f2e168face2c61d1b2b769b16befd23b6b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -317,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.65.0"
+version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ba2c5c0f2618937ce3d4a5ad574b86775576fa24006bcb3128c6e2cbf3c34e"
+checksum = "3d781684ce9da2f82da4e23eaf753310d5ddb05efe2d91cd59033828727218f5"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -328,14 +312,14 @@ dependencies = [
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand",
  "hex",
  "hmac",
  "http 0.2.12",
@@ -351,15 +335,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.50.0"
+version = "1.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ca43a4ef210894f93096039ef1d6fa4ad3edfabb3be92b80908b9f2e4b4eab"
+checksum = "33993c0b054f4251ff2946941b56c26b582677303eeca34087594eb901ece022"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -373,15 +357,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.51.0"
+version = "1.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abaf490c2e48eed0bb8e2da2fb08405647bd7f253996e0f93b981958ea0f73b0"
+checksum = "3bd3ceba74a584337a8f3839c818f14f1a2288bfd24235120ff22d7e17a0dd54"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -395,15 +379,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.51.0"
+version = "1.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68fde0d69c8bfdc1060ea7da21df3e39f6014da316783336deff0a9ec28f4bf"
+checksum = "07835598e52dd354368429cb2abf447ce523ea446d0a533a63cb42cd0d2d9280"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -418,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
+checksum = "690118821e46967b3c4501d67d7d52dd75106a9c54cf36cefa1985cedbe94e05"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -447,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -458,15 +442,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.13"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1a71073fca26775c8b5189175ea8863afb1c9ea2cceb02a5de5ad9dfbaa795"
+checksum = "f2f45a1c384d7a393026bc5f5c177105aa9fa68e4749653b985707ac27d77295"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "crc32c",
  "crc32fast",
+ "crc64fast-nvme",
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -479,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.5"
+version = "0.60.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef7d0a272725f87e51ba2bf89f8c21e4df61b9e49ae1ac367a6d69916ef7c90"
+checksum = "8b18559a41e0c909b77625adf2b8c50de480a8041e5e4a3f5f7d177db70abc5a"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -490,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.11"
+version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -511,18 +496,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.60.7"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -539,22 +515,22 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.4"
+version = "1.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f20685047ca9d6f17b994a07f629c813f08b5bce65523e47124879e60103d45"
+checksum = "865f7050bbc7107a6c98a397a9fcd9413690c27fa718446967cf03b2d3ac517e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "hyper-rustls",
  "once_cell",
  "pin-project-lite",
@@ -583,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.9"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd94a32b3a7d55d3806fe27d98d3ad393050439dd05eb53ece36ec5e3d3510"
+checksum = "a28f6feb647fb5e0d5b50f0472c19a7db9462b74e2fec01bb0b44eedcc834e97"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -608,12 +584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types-convert"
-version = "0.60.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f280f434214856abace637b1f944d50ccca216814813acd195cdd7f206ce17f"
-
-[[package]]
 name = "aws-smithy-xml"
 version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+checksum = "b0df5a18c4f951c645300d365fec53a61418bcf4650f604f85fe2a665bfaa0c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -638,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -658,7 +628,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -690,26 +660,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom 0.2.15",
+ "getrandom",
  "instant",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -717,12 +687,6 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -763,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "block-buffer"
@@ -790,9 +754,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bytes-utils"
@@ -805,10 +769,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.1.7"
+name = "cbindgen"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+dependencies = [
+ "clap",
+ "heck 0.4.1",
+ "indexmap 2.7.1",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -828,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -842,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -852,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -864,11 +850,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -876,15 +862,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -901,25 +887,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -949,12 +920,27 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
@@ -975,10 +961,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.20"
+name = "crc64fast-nvme"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d5e2ee08013e3f228d6d2394116c4549a6df77708442c62d887d83f68ef2ee37"
+dependencies = [
+ "cbindgen",
+ "crc",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -987,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -998,7 +988,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1014,14 +1004,13 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.9.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
 dependencies = [
  "async-trait",
  "deadpool-runtime",
  "num_cpus",
- "retain_mut",
  "tokio",
 ]
 
@@ -1052,15 +1041,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "convert_case",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
  "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1072,6 +1069,17 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1118,10 +1126,20 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -1138,6 +1156,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,34 +1176,19 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1180,7 +1196,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1192,9 +1208,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -1222,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1237,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1247,15 +1263,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1264,30 +1280,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
-
-[[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1296,27 +1297,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1342,37 +1337,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"
@@ -1381,7 +1365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1397,7 +1381,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.3.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1416,7 +1400,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.3.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1434,10 +1418,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1452,6 +1432,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1461,6 +1447,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1534,31 +1526,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel",
- "base64 0.13.1",
- "futures-lite",
- "http 0.2.12",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
-]
-
-[[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -1589,9 +1560,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1604,7 +1575,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1613,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1640,7 +1611,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -1654,7 +1625,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1663,15 +1634,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.30",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1685,9 +1659,9 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1695,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1717,13 +1691,142 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1738,19 +1841,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
-
-[[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "instant"
@@ -1763,11 +1860,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -1780,25 +1877,26 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1827,25 +1925,25 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http",
  "aws-smithy-types",
- "aws-smithy-types-convert",
  "backoff",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "chacha",
  "chrono",
  "clap",
  "derive_more",
  "duct",
- "env_logger",
+ "env_logger 0.11.6",
  "futures",
- "generic-array",
  "hex",
- "http 0.2.12",
+ "http 1.2.0",
+ "http-body-util",
  "human-size",
  "humansize",
  "humantime",
- "hyper 0.14.30",
+ "hyper 1.5.2",
  "hyper-tls",
+ "hyper-util",
  "linked-hash-map",
  "log",
  "opentelemetry",
@@ -1857,16 +1955,17 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "pretty_env_logger",
- "rand 0.8.5",
+ "rand",
  "redis",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-util",
  "toml",
+ "tower 0.5.2",
  "tracing",
  "tracing-log",
  "tracing-opentelemetry",
@@ -1878,15 +1977,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "linked-hash-map"
@@ -1899,9 +1998,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1915,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru"
@@ -1983,22 +2088,21 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -2040,6 +2144,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,30 +2183,30 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2122,18 +2236,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.1+3.3.1"
+version = "300.4.1+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -2152,7 +2266,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -2194,7 +2308,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tracing",
@@ -2232,7 +2346,7 @@ dependencies = [
  "ordered-float",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2248,9 +2362,9 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2258,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65ee1f9701bf938026630b455d5315f490640234259037edb259798b3bcf85e"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
@@ -2277,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "outref"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "overload"
@@ -2297,12 +2411,6 @@ dependencies = [
  "elliptic-curve",
  "sha2",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -2335,18 +2443,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2355,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2377,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "powerfmt"
@@ -2389,11 +2497,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2402,15 +2510,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
 dependencies = [
- "env_logger",
+ "env_logger 0.10.2",
  "log",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -2440,24 +2548,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
 ]
 
 [[package]]
@@ -2467,18 +2562,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2488,16 +2573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -2506,34 +2582,28 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
 name = "redis"
-version = "0.23.3"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f49cdc0bb3f412bf8e7d1bd90fe1d9eb10bc5c399ba90973c14662a27b3f8ba"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "bytes",
  "combine",
  "futures-util",
+ "itertools",
  "itoa",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tokio-util",
  "url",
@@ -2541,23 +2611,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2571,13 +2641,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2594,15 +2664,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rfc6979"
@@ -2623,7 +2687,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom",
  "libc",
  "spin",
  "untrusted",
@@ -2638,24 +2702,24 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2672,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
  "once_cell",
@@ -2706,7 +2770,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.0.1",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -2729,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
@@ -2756,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -2768,11 +2832,11 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2820,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.0",
@@ -2833,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2843,24 +2907,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2869,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -2880,34 +2944,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
  "serde",
 ]
 
@@ -2959,6 +3000,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,7 +3021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -2994,19 +3041,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3029,6 +3066,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,9 +3085,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3058,15 +3101,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
-name = "tempfile"
-version = "3.10.1"
+name = "synstructure"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.0",
+ "fastrand",
+ "getrandom",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3080,18 +3136,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3110,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3130,34 +3206,29 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3166,16 +3237,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3208,7 +3279,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "tokio",
 ]
 
@@ -3225,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3242,9 +3313,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3263,11 +3334,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3289,7 +3360,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -3297,11 +3368,11 @@ dependencies = [
  "prost",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tokio-rustls 0.26.1",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3318,7 +3389,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -3328,22 +3399,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-layer"
-version = "0.3.2"
+name = "tower"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3352,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3363,9 +3448,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3402,9 +3487,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -3412,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3445,33 +3530,21 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.23"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3481,14 +3554,13 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -3498,6 +3570,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3505,18 +3589,18 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -3537,12 +3621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3553,35 +3631,30 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -3590,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3600,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3613,9 +3686,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-time"
@@ -3645,11 +3721,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3751,34 +3827,48 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wiremock"
-version = "0.5.22"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a3a53eaf34f390dd30d7b1b078287dd05df2aa2e21a589ccb80f5c7253c2e9"
+checksum = "7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "deadpool",
  "futures",
- "futures-timer",
- "http-types",
- "hyper 0.14.30",
+ "http 1.2.0",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
  "log",
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "tokio",
+ "url",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xmlparser"
@@ -3787,13 +3877,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
-name = "zerocopy"
-version = "0.6.6"
+name = "yoke"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
- "byteorder",
- "zerocopy-derive 0.6.6",
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -3802,18 +3906,8 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "byteorder",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -3828,7 +3922,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,318 +226,412 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "0.55.3"
+version = "1.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdcf0d683fe9c23d32cf5b53c9918ea0a500375a9fb20109802552658e576c9"
+checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
 dependencies = [
  "aws-credential-types",
- "aws-http",
+ "aws-runtime",
  "aws-sdk-sso",
+ "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 1.9.0",
+ "fastrand 2.1.0",
  "hex",
  "http 0.2.12",
- "hyper 0.14.30",
- "ring 0.16.20",
+ "ring",
  "time",
  "tokio",
- "tower",
  "tracing",
+ "url",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-credential-types"
-version = "0.55.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
- "fastrand 1.9.0",
- "tokio",
- "tracing",
  "zeroize",
 ]
 
 [[package]]
-name = "aws-endpoint"
-version = "0.55.3"
+name = "aws-runtime"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
-dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
- "http 0.2.12",
- "regex",
- "tracing",
-]
-
-[[package]]
-name = "aws-http"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
+checksum = "b5ac934720fbb46206292d2c75b57e67acfc56fe7dfd34fb9a02334af08409ea"
 dependencies = [
  "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "fastrand 2.1.0",
  "http 0.2.12",
  "http-body 0.4.6",
- "lazy_static",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "0.28.0"
+version = "1.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e69ffb50ec065a564769aa61158be806b66a7d77301a3459d1c663a421eaab"
+checksum = "a18e18b3cf6b75c1fcb15e677f6dbd2a6d8dfe4d168e0a36721f7a6167c6c829"
 dependencies = [
  "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
+ "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 1.9.0",
+ "fastrand 2.1.0",
  "http 0.2.12",
- "regex",
- "tokio-stream",
- "tower",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
 [[package]]
-name = "aws-sdk-sso"
-version = "0.28.0"
+name = "aws-sdk-s3"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b812340d86d4a766b2ca73f740dfd47a97c2dff0c06c8517a16d88241957e4"
+checksum = "d3ba2c5c0f2618937ce3d4a5ad574b86775576fa24006bcb3128c6e2cbf3c34e"
 dependencies = [
  "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
+ "aws-runtime",
+ "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-client",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand 2.1.0",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "lru",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ca43a4ef210894f93096039ef1d6fa4ad3edfabb3be92b80908b9f2e4b4eab"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json 0.61.1",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "http 0.2.12",
- "regex",
- "tokio-stream",
- "tower",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abaf490c2e48eed0bb8e2da2fb08405647bd7f253996e0f93b981958ea0f73b0"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json 0.61.1",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.28.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265fac131fbfc188e5c3d96652ea90ecc676a934e3174eaaee523c6cec040b3b"
+checksum = "b68fde0d69c8bfdc1060ea7da21df3e39f6014da316783336deff0a9ec28f4bf"
 dependencies = [
  "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
+ "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "bytes",
  "http 0.2.12",
- "regex",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-sig-auth"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-http",
- "aws-types",
- "http 0.2.12",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "0.55.3"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
+checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
 dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "http 0.2.12",
+ "http 1.2.0",
  "once_cell",
+ "p256",
  "percent-encoding",
- "regex",
- "sha2 0.10.8",
+ "ring",
+ "sha2",
+ "subtle",
  "time",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.55.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bda3996044c202d75b91afeb11a9afae9db9a721c6a7a427410018e286b880"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
 dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
- "tokio-stream",
 ]
 
 [[package]]
-name = "aws-smithy-client"
-version = "0.55.3"
+name = "aws-smithy-checksums"
+version = "0.60.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
+checksum = "ba1a71073fca26775c8b5189175ea8863afb1c9ea2cceb02a5de5ad9dfbaa795"
 dependencies = [
- "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-http-tower",
  "aws-smithy-types",
  "bytes",
- "fastrand 1.9.0",
+ "crc32c",
+ "crc32fast",
+ "hex",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-rustls",
- "lazy_static",
+ "md-5",
  "pin-project-lite",
- "rustls 0.20.9",
- "tokio",
- "tower",
+ "sha1",
+ "sha2",
  "tracing",
 ]
 
 [[package]]
-name = "aws-smithy-http"
-version = "0.55.3"
+name = "aws-smithy-eventstream"
+version = "0.60.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
+checksum = "cef7d0a272725f87e51ba2bf89f8c21e4df61b9e49ae1ac367a6d69916ef7c90"
 dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-tower"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
-dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
- "pin-project-lite",
- "tower",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.55.3"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.55.3"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98819eb0b04020a1c791903533b638534ae6c12e2aceda3e6e6fba015608d51d"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "0.55.3"
+name = "aws-smithy-runtime"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
+checksum = "9f20685047ca9d6f17b994a07f629c813f08b5bce65523e47124879e60103d45"
 dependencies = [
- "base64-simd",
- "itoa",
- "num-integer",
- "ryu",
- "time",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand 2.1.0",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.30",
+ "hyper-rustls",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
-name = "aws-smithy-xml"
-version = "0.55.3"
+name = "aws-smithy-runtime-api"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
+checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.2.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbd94a32b3a7d55d3806fe27d98d3ad393050439dd05eb53ece36ec5e3d3510"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.2.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-types-convert"
+version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f280f434214856abace637b1f944d50ccca216814813acd195cdd7f206ce17f"
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.55.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 0.2.12",
  "rustc_version",
  "tracing",
 ]
@@ -619,6 +713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +747,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,15 +766,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -739,7 +836,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-targets",
 ]
@@ -814,6 +910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +957,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +981,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,16 +1010,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -907,6 +1030,16 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -932,43 +1065,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -984,10 +1087,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "env_logger"
@@ -1040,10 +1175,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "foreign-types"
@@ -1224,6 +1375,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1440,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,21 +1470,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1471,17 +1634,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
+ "futures-util",
  "http 0.2.12",
  "hyper 0.14.30",
  "log",
- "rustls 0.20.9",
+ "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1660,6 +1824,10 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-dynamodb",
+ "aws-sdk-s3",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-smithy-types-convert",
  "backoff",
  "base64 0.21.7",
  "bytes",
@@ -1691,13 +1859,9 @@ dependencies = [
  "pretty_env_logger",
  "rand 0.8.5",
  "redis",
- "rusoto_core",
- "rusoto_credential",
- "rusoto_s3",
- "rusoto_sts",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1723,16 +1887,6 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -1766,6 +1920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,13 +1945,12 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
-version = "0.9.1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -1925,12 +2087,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -2132,6 +2288,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,6 +2364,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2372,17 +2549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
-dependencies = [
- "getrandom 0.2.15",
- "libredox",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,18 +2605,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
-name = "ring"
-version = "0.16.20"
+name = "rfc6979"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -2457,106 +2625,9 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rusoto_core"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
-dependencies = [
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "crc32fast",
- "futures",
- "http 0.2.12",
- "hyper 0.14.30",
- "hyper-rustls",
- "lazy_static",
- "log",
- "rusoto_credential",
- "rusoto_signature",
- "rustc_version",
- "serde",
- "serde_json",
- "tokio",
- "xml-rs",
-]
-
-[[package]]
-name = "rusoto_credential"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0a6c13db5aad6047b6a44ef023dbbc21a056b6dab5be3b79ce4283d5c02d05"
-dependencies = [
- "async-trait",
- "chrono",
- "dirs-next",
- "futures",
- "hyper 0.14.30",
- "serde",
- "serde_json",
- "shlex",
- "tokio",
- "zeroize",
-]
-
-[[package]]
-name = "rusoto_s3"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aae4677183411f6b0b412d66194ef5403293917d66e70ab118f07cc24c5b14d"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "rusoto_core",
- "xml-rs",
-]
-
-[[package]]
-name = "rusoto_signature"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ae95491c8b4847931e291b151127eccd6ff8ca13f33603eb3d0035ecb05272"
-dependencies = [
- "base64 0.13.1",
- "bytes",
- "chrono",
- "digest 0.9.0",
- "futures",
- "hex",
- "hmac 0.11.0",
- "http 0.2.12",
- "hyper 0.14.30",
- "log",
- "md-5",
- "percent-encoding",
- "pin-project-lite",
- "rusoto_credential",
- "rustc_version",
- "serde",
- "sha2 0.9.9",
- "tokio",
-]
-
-[[package]]
-name = "rusoto_sts"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1643f49aa67cb7cb895ebac5a2ff3f991c6dbdc58ad98b28158cd5706aecd1d"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "rusoto_core",
- "serde_urlencoded",
- "xml-rs",
 ]
 
 [[package]]
@@ -2589,14 +2660,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.16.20",
+ "ring",
+ "rustls-webpki 0.101.7",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -2607,9 +2678,9 @@ checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -2664,13 +2735,23 @@ checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -2706,8 +2787,22 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2817,23 +2912,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
 
 [[package]]
 name = "sha2"
@@ -2843,7 +2936,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2866,18 +2959,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2917,15 +3014,19 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "strsim"
@@ -3093,13 +3194,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.20.9",
+ "rustls 0.21.12",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -3245,7 +3345,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3373,12 +3472,6 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -3525,16 +3618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
-name = "web-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3542,16 +3625,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3706,12 +3779,6 @@ dependencies = [
  "serde_json",
  "tokio",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,12 @@ license = "MIT"
 askama = "0.12"
 async-stream = "0.3"
 async-trait = "0.1"
-aws-config = { version = "0.55.3", optional = true }
-aws-sdk-dynamodb = { version = "0.28.0", optional = true }
+aws-config = { version = "1.5.10", optional = true }
+aws-sdk-dynamodb = { version = "1.55.0", optional = true }
+aws-sdk-s3 = { version = "1.65.0", features = ["rt-tokio"] }
+aws-smithy-types = { version = "1.2.9" }
+aws-smithy-types-convert = "0.60.8"
+aws-smithy-http = "0.60.11"
 backoff = { version = "0.4", features = ["tokio"] }
 bytes = "1"
 chacha = "0.3"
@@ -95,24 +99,6 @@ duct = "0.13"
 env_logger = "0.10"
 toml = "0.7"
 wiremock = "0.5"
-
-[dependencies.rusoto_core]
-version = "0.48"
-default-features = false
-features = ["rustls"]
-
-[dependencies.rusoto_credential]
-version = "0.48"
-
-[dependencies.rusoto_sts]
-version = "0.48"
-features = ["rustls"]
-default-features = false
-
-[dependencies.rusoto_s3]
-version = "0.48"
-default-features = false
-features = ["rustls"]
 
 [features]
 default = ["dynamodb", "redis", "otel"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,32 +21,27 @@ license = "MIT"
 askama = "0.12"
 async-stream = "0.3"
 async-trait = "0.1"
-aws-config = { version = "1.5.10", optional = true }
-aws-sdk-dynamodb = { version = "1.55.0", optional = true }
-aws-sdk-s3 = { version = "1.65.0", features = ["rt-tokio"] }
-aws-smithy-types = { version = "1.2.9" }
-aws-smithy-types-convert = "0.60.8"
-aws-smithy-http = "0.60.11"
+aws-config = { version = "1.5" }
+aws-sdk-dynamodb = { version = "1.56", optional = true }
+aws-sdk-s3 = { version = "1.66", features = ["rt-tokio"] }
+aws-smithy-types = { version = "1.2" }
+aws-smithy-http = "0.60"
 backoff = { version = "0.4", features = ["tokio"] }
 bytes = "1"
 chacha = "0.3"
-chrono = "0.4.26"
-derive_more = "0.99"
+chrono = "0.4"
+derive_more = { version = "1.0", features = ["display", "from"] }
 futures = "0.3"
-generic-array = "0.14"
 hex = "0.4"
-http = "0.2"
+http = "1.2"
+http-body-util = "0.1"
 human-size = "0.4"
 humansize = "2"
 humantime = "2"
-hyper = { version = "0.14", features = [
-  "server",
-  "http1",
-  "http2",
-  "tcp",
-  "stream",
-] }
-hyper-tls = { version = "0.5.0", features = ["vendored"] }
+hyper = { version = "1.5", features = ["full"] }
+hyper-util = { version = "0.1", features = ["full"] }
+hyper-tls = { version = "0.6", features = ["vendored"] }
+tower = { version = "0.5", features = ["util"] }
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }
 log = "0.4"
 pretty_env_logger = "0.5"
@@ -58,21 +53,18 @@ clap = { version = "4.3", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 url = "2"
-uuid = { version = "1.1", features = ["v4"] }
+uuid = { version = "1.11", features = ["v4"] }
 anyhow = "1.0"
-thiserror = "1.0"
-redis = { version = "0.23.0", optional = true, features = [
-  "aio",
-  "tokio-comp",
-] }
-base64 = { version = "0.21.2" }
+thiserror = "2.0"
+redis = { version = "0.27", optional = true, features = ["aio", "tokio-comp"] }
+base64 = { version = "0.22" }
 parking_lot = { version = "0.12" }
 
-opentelemetry = { version = "0.27.1", optional = true }
-opentelemetry_sdk = { version = "0.27.1", features = [
+opentelemetry = { version = "0.27", optional = true }
+opentelemetry_sdk = { version = "0.27", features = [
   "rt-tokio",
 ], optional = true }
-opentelemetry-otlp = { version = "0.27.0", features = [
+opentelemetry-otlp = { version = "0.27", features = [
   "http-proto",
   "tls",
   "tls-roots",
@@ -90,15 +82,15 @@ tracing-subscriber = { version = "0.3", features = [
   "json",
   "registry",
 ], optional = true }
-opentelemetry-stdout = "0.27.0"
+opentelemetry-stdout = "0.27"
 
 [dev-dependencies]
 rand = "0.8"
 tempfile = "3"
 duct = "0.13"
-env_logger = "0.10"
-toml = "0.7"
-wiremock = "0.5"
+env_logger = "0.11"
+toml = "0.8"
+wiremock = "0.6"
 
 [features]
 default = ["dynamodb", "redis", "otel"]
@@ -106,14 +98,15 @@ default = ["dynamodb", "redis", "otel"]
 # stream.
 faulty = ["rand"]
 redis = ["dep:redis"]
-dynamodb = ["dep:aws-config", "dep:aws-sdk-dynamodb"]
+dynamodb = ["dep:aws-sdk-dynamodb"]
 otel = [
   "dep:opentelemetry",
   "dep:opentelemetry_sdk",
   "dep:opentelemetry-otlp",
-  "dep:opentelemetry-semantic-conventions",
+  "dep:opentelemetry-http",
   "dep:opentelemetry-appender-tracing",
+  "dep:opentelemetry-semantic-conventions",
   "dep:tracing-opentelemetry",
-  "dep:tracing-subscriber",
   "dep:tracing-log",
+  "dep:tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "lfs-rs"
 version = "0.3.6"
-authors = ["Jason White <rust@jasonwhite.io>", "The Believer Company <believeross@believer.gg>"]
+authors = [
+  "Jason White <rust@jasonwhite.io>",
+  "The Believer Company <believeross@believer.gg>",
+]
 edition = "2021"
 description = """
 A high-performance, caching Git LFS server with an AWS S3 back-end.
@@ -32,7 +35,13 @@ http = "0.2"
 human-size = "0.4"
 humansize = "2"
 humantime = "2"
-hyper = { version = "0.14", features = ["server", "http1", "http2", "tcp", "stream"] }
+hyper = { version = "0.14", features = [
+  "server",
+  "http1",
+  "http2",
+  "tcp",
+  "stream",
+] }
 hyper-tls = { version = "0.5.0", features = ["vendored"] }
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }
 log = "0.4"
@@ -48,16 +57,36 @@ url = "2"
 uuid = { version = "1.1", features = ["v4"] }
 anyhow = "1.0"
 thiserror = "1.0"
-redis = { version = "0.23.0", optional = true, features = ["aio", "tokio-comp"] }
+redis = { version = "0.23.0", optional = true, features = [
+  "aio",
+  "tokio-comp",
+] }
 base64 = { version = "0.21.2" }
 parking_lot = { version = "0.12" }
 
-opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"], optional = true }
-opentelemetry-otlp = { version = "0.12.0", features = ["http-proto", "tls", "tls-roots", "tokio", "tonic"], optional = true }
-opentelemetry-http = { version = "0.8", features = ["hyper", "tokio"], optional = true }
+opentelemetry = { version = "0.27.1", optional = true }
+opentelemetry_sdk = { version = "0.27.1", features = [
+  "rt-tokio",
+], optional = true }
+opentelemetry-otlp = { version = "0.27.0", features = [
+  "http-proto",
+  "tls",
+  "tls-roots",
+  "tokio",
+  "tonic",
+], optional = true }
+opentelemetry-http = { version = "0.27", optional = true }
+opentelemetry-appender-tracing = { version = "0.27", optional = true }
+opentelemetry-semantic-conventions = { version = "0.27", optional = true }
 tracing = { version = "0.1", features = ["attributes"] }
-tracing-opentelemetry = { version = "0.19", optional = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"], optional = true }
+tracing-opentelemetry = { version = "0.28", optional = true }
+tracing-log = { version = "0.2", optional = true }
+tracing-subscriber = { version = "0.3", features = [
+  "env-filter",
+  "json",
+  "registry",
+], optional = true }
+opentelemetry-stdout = "0.27.0"
 
 [dev-dependencies]
 rand = "0.8"
@@ -69,7 +98,7 @@ wiremock = "0.5"
 
 [dependencies.rusoto_core]
 version = "0.48"
-default_features = false
+default-features = false
 features = ["rustls"]
 
 [dependencies.rusoto_credential]
@@ -78,11 +107,11 @@ version = "0.48"
 [dependencies.rusoto_sts]
 version = "0.48"
 features = ["rustls"]
-default_features = false
+default-features = false
 
 [dependencies.rusoto_s3]
 version = "0.48"
-default_features = false
+default-features = false
 features = ["rustls"]
 
 [features]
@@ -92,4 +121,13 @@ default = ["dynamodb", "redis", "otel"]
 faulty = ["rand"]
 redis = ["dep:redis"]
 dynamodb = ["dep:aws-config", "dep:aws-sdk-dynamodb"]
-otel = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry", "dep:tracing-subscriber"]
+otel = [
+  "dep:opentelemetry",
+  "dep:opentelemetry_sdk",
+  "dep:opentelemetry-otlp",
+  "dep:opentelemetry-semantic-conventions",
+  "dep:opentelemetry-appender-tracing",
+  "dep:tracing-opentelemetry",
+  "dep:tracing-subscriber",
+  "dep:tracing-log",
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM rust:1.78 as build
+FROM rust:1.83 as build
 
 ENV CARGO_BUILD_TARGET=x86_64-unknown-linux-musl
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN \
-	apt-get update && \
-	apt-get -y install ca-certificates musl-tools && \
-	rustup target add ${CARGO_BUILD_TARGET}
+  apt-get update && \
+  apt-get -y install ca-certificates musl-tools && \
+  rustup target add ${CARGO_BUILD_TARGET}
 
 ENV PKG_CONFIG_ALLOW_CROSS=1
 
@@ -27,9 +27,9 @@ COPY ./ ./
 RUN cargo build --release
 
 RUN \
-	mkdir -p /build && \
-	cp target/${CARGO_BUILD_TARGET}/release/lfs-rs /build/ && \
-	strip /build/lfs-rs
+  mkdir -p /build && \
+  cp target/${CARGO_BUILD_TARGET}/release/lfs-rs /build/ && \
+  strip /build/lfs-rs
 
 # Use scratch so we can get an itty-bitty-teeny-tiny image. This requires us to
 # use musl when building the application.

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,66 +18,132 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use std::collections::{BTreeMap, HashMap};
-use std::fmt;
-use std::io;
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+    task::{Context, Poll},
+    time::Duration,
+};
 
-use core::task::{Context, Poll};
-
-use askama::Template;
 use futures::{
     future::{self, BoxFuture},
-    stream::TryStreamExt,
+    TryStreamExt,
 };
-use http::HeaderMap;
-use http::{self, header, StatusCode, Uri};
-use hyper::{self, body::Body, service::Service, Method, Request, Response};
 
+use http::{self, header, HeaderMap, StatusCode, Uri};
+use http_body_util::{BodyDataStream, BodyExt, StreamBody};
+use hyper::{
+    self,
+    body::{Frame, Incoming},
+    Method, Request, Response,
+};
+use tower::Service;
 use url::form_urlencoded;
+
+use askama::Template;
+use bytes::Bytes;
 
 use crate::auth::UserRepoInfo;
 use crate::error::Error;
 use crate::hyperext::RequestExt;
 use crate::lfs;
-use crate::locks::LockStoreError;
 use crate::locks::{
     CreateLockBatchRequest, CreateLockRequest, ListLocksResponse, Lock,
-    LockBatchOuter, LockOuter, LockStorage, OwnerInfo, ReleaseLockBatchRequest,
-    ReleaseLockRequest, VerifyLocksRequest, VerifyLocksResponse,
+    LockBatchOuter, LockOuter, LockStorage, LockStoreError, OwnerInfo,
+    ReleaseLockBatchRequest, ReleaseLockRequest, VerifyLocksRequest,
+    VerifyLocksResponse,
 };
 use crate::storage::{LFSObject, Namespace, Storage, StorageKey};
-use crate::util::from_json;
-use crate::util::into_json;
-use std::time::Duration;
+use crate::{empty, from_json, full, into_json};
+
+#[cfg(feature = "otel")]
+use crate::util::RedactedHeaders;
+#[cfg(feature = "otel")]
+use opentelemetry::trace::FutureExt;
 #[cfg(feature = "otel")]
 use tracing::instrument;
+#[cfg(feature = "otel")]
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-const UPLOAD_EXPIRATION: Duration = Duration::from_secs(30 * 60);
+const PRESIGNED_URL_EXPIRATION: Duration = Duration::from_secs(30 * 60);
 
-fn handle_lock_error_response(err: anyhow::Error) -> (StatusCode, Body) {
+fn handle_lock_error_response(err: anyhow::Error) -> (StatusCode, BoxBody) {
     match err.downcast_ref::<LockStoreError>() {
         Some(e @ LockStoreError::CreateConflict(l)) => (
             StatusCode::CONFLICT,
-            into_json(&lfs::BatchResponseError {
-                locks: Some(l.clone()),
-                message: e.to_string(),
-                documentation_url: None,
-                request_id: None,
-            })
-            .unwrap(),
+            full(
+                into_json(&lfs::BatchResponseError {
+                    locks: Some(l.clone()),
+                    message: e.to_string(),
+                    documentation_url: None,
+                    request_id: None,
+                })
+                .unwrap_or_default(),
+            ),
         ),
         Some(LockStoreError::NotImplemented) => {
-            (StatusCode::NOT_FOUND, Body::empty())
+            (StatusCode::NOT_FOUND, empty())
         }
-        None | Some(LockStoreError::InternalServerError) => (
+        #[cfg(feature = "redis")]
+        Some(LockStoreError::RedisError(e)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            into_json(&lfs::BatchResponseError {
-                locks: None,
-                message: err.to_string(),
-                documentation_url: None,
-                request_id: None,
-            })
-            .unwrap(),
+            full(
+                into_json(&lfs::BatchResponseError {
+                    locks: None,
+                    message: e.to_string(),
+                    documentation_url: None,
+                    request_id: None,
+                })
+                .unwrap_or_default(),
+            ),
+        ),
+        Some(LockStoreError::DeleteNotFound(e)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            full(
+                into_json(&lfs::BatchResponseError {
+                    locks: None,
+                    message: e.to_string(),
+                    documentation_url: None,
+                    request_id: None,
+                })
+                .unwrap_or_default(),
+            ),
+        ),
+        Some(LockStoreError::LockNotFound(e)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            full(
+                into_json(&lfs::BatchResponseError {
+                    locks: None,
+                    message: e.to_string(),
+                    documentation_url: None,
+                    request_id: None,
+                })
+                .unwrap_or_default(),
+            ),
+        ),
+        Some(LockStoreError::InternalServerError(e)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            full(
+                into_json(&lfs::BatchResponseError {
+                    locks: None,
+                    message: e.to_string(),
+                    documentation_url: None,
+                    request_id: None,
+                })
+                .unwrap_or_default(),
+            ),
+        ),
+        None => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            full(
+                into_json(&lfs::BatchResponseError {
+                    locks: None,
+                    message: err.to_string(),
+                    documentation_url: None,
+                    request_id: None,
+                })
+                .unwrap_or_default(),
+            ),
         ),
     }
 }
@@ -101,6 +167,9 @@ impl<S, L> App<S, L> {
     }
 }
 
+pub type Req = Request<Incoming>;
+pub type BoxBody = http_body_util::combinators::UnsyncBoxBody<Bytes, Error>;
+
 impl<S, L> App<S, L>
 where
     S: Storage + Send + Sync,
@@ -110,32 +179,32 @@ where
 {
     /// Handles the index route.
     #[cfg_attr(feature = "otel", instrument(level = "debug", skip(req)))]
-    fn index(req: Request<Body>) -> Result<Response<Body>, Error> {
+    fn index(req: Req) -> Result<Response<BoxBody>, Error> {
         let template = IndexTemplate {
             title: "Rudolfs",
-            api: req.base_uri().path_and_query("/api").build().unwrap(),
+            api: req.base_uri().path_and_query("/api").build()?,
         };
 
         Ok(Response::builder()
             .status(StatusCode::OK)
-            .body(template.render()?.into())?)
+            .body(full(template.render()?))?)
     }
 
     /// Generates a "404 not found" response.
     #[cfg_attr(feature = "otel", instrument(level = "info", skip(_req)))]
-    fn not_found(_req: Request<Body>) -> Result<Response<Body>, Error> {
+    fn not_found(_req: Req) -> Result<Response<BoxBody>, Error> {
         Ok(Response::builder()
             .status(StatusCode::NOT_FOUND)
-            .body("Not found".into())?)
+            .body(full("Not found"))?)
     }
 
     /// Generates a "403 forbidden" response.
     #[cfg_attr(feature = "otel", instrument(level = "info", skip(_req)))]
-    fn forbidden(_req: Request<Body>) -> Result<Response<Body>, Error> {
+    fn forbidden(_req: Req) -> Result<Response<BoxBody>, Error> {
         Ok(Response::builder()
             .status(StatusCode::FORBIDDEN)
             .header("Lfs-Authenticate", "Basic realm=\"GitHub\"")
-            .body(Body::empty())?)
+            .body(empty())?)
     }
 
     /// Handles `/api` routes.
@@ -146,8 +215,8 @@ where
     async fn api(
         storage: S,
         locks: L,
-        req: Request<Body>,
-    ) -> Result<Response<Body>, Error> {
+        req: Request<Incoming>,
+    ) -> Result<Response<BoxBody>, Error> {
         let mut parts = req.uri().path().split('/').filter(|s| !s.is_empty());
 
         // Skip over the '/api' part.
@@ -161,7 +230,7 @@ where
             _ => {
                 return Ok(Response::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(Body::from("Missing org/project in URL"))?)
+                    .body(full("Missing org/project in URL"))?)
             }
         };
 
@@ -174,7 +243,7 @@ where
                     None => {
                         return Ok(Response::builder()
                             .status(StatusCode::BAD_REQUEST)
-                            .body(Body::from("Missing OID parameter."))?)
+                            .body(full("Missing OID parameter."))?)
                     }
                 };
 
@@ -200,14 +269,14 @@ where
                 if let Some(user) = user {
                     match (req.method(), parts.next()) {
                         (&Method::GET, None) => {
-                            if !user.permissions.unwrap().pull {
+                            if !user.permissions.unwrap_or_default().pull {
                                 return Self::forbidden(req);
                             }
 
                             Self::list_locks(locks, req, namespace).await
                         }
                         (&Method::POST, None) => {
-                            if !user.permissions.unwrap().push {
+                            if !user.permissions.unwrap_or_default().push {
                                 return Self::forbidden(req);
                             }
 
@@ -220,7 +289,7 @@ where
                             .await
                         }
                         (&Method::POST, Some("batch")) => {
-                            if !user.permissions.unwrap().push {
+                            if !user.permissions.unwrap_or_default().push {
                                 return Self::forbidden(req);
                             }
 
@@ -247,7 +316,7 @@ where
                             }
                         }
                         (&Method::POST, Some("verify")) => {
-                            if !user.permissions.unwrap().push {
+                            if !user.permissions.unwrap_or_default().push {
                                 return Self::forbidden(req);
                             }
 
@@ -260,7 +329,7 @@ where
                             .await
                         }
                         (&Method::POST, Some(id)) => {
-                            if !user.permissions.unwrap().push {
+                            if !user.permissions.unwrap_or_default().push {
                                 return Self::forbidden(req);
                             }
 
@@ -297,19 +366,27 @@ where
     )]
     async fn download(
         storage: S,
-        _req: Request<Body>,
+        _req: Req,
         key: StorageKey,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         if let Some(object) = storage.get(&key).await? {
+            let len = &object.len().to_string();
+            let body_stream = StreamBody::new(
+                object
+                    .stream()
+                    .map_ok(Frame::data)
+                    .map_err(|e: std::io::Error| e.into()),
+            );
+            let boxed_body = body_stream.boxed_unsync();
             Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, "application/octet-stream")
-                .header(header::CONTENT_LENGTH, object.len())
-                .body(Body::wrap_stream(object.stream()))?)
+                .header(header::CONTENT_LENGTH, len)
+                .body(boxed_body)?)
         } else {
             Ok(Response::builder()
                 .status(StatusCode::NOT_FOUND)
-                .body(Body::empty())?)
+                .body(empty())?)
         }
     }
 
@@ -320,9 +397,9 @@ where
     )]
     async fn upload(
         storage: S,
-        req: Request<Body>,
+        req: Request<Incoming>,
         key: StorageKey,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         let len = req
             .headers()
             .get("Content-Length")
@@ -334,23 +411,22 @@ where
             None => {
                 return Response::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(Body::from("Invalid Content-Length header."))
+                    .body(full("Invalid Content-Length header."))
                     .map_err(Into::into);
             }
         };
 
         // Verify the SHA256 of the uploaded object as it is being uploaded.
-        let stream = req
-            .into_body()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
+        let body = req.into_body();
+        let stream = BodyDataStream::new(body)
+            .try_filter_map(|chunk| async { Ok(Some(chunk)) })
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
 
         let object = LFSObject::new(len, Box::pin(stream));
 
         storage.put(key, object).await?;
 
-        Ok(Response::builder()
-            .status(StatusCode::OK)
-            .body(Body::empty())?)
+        Ok(Response::builder().status(StatusCode::OK).body(empty())?)
     }
 
     /// Verifies that an LFS object exists on the server.
@@ -360,9 +436,9 @@ where
     )]
     async fn verify(
         storage: S,
-        req: Request<Body>,
+        req: Request<Incoming>,
         namespace: Namespace,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         let val: lfs::VerifyRequest = from_json(req.into_body()).await?;
         let key = StorageKey::new(namespace, val.oid);
 
@@ -370,14 +446,14 @@ where
             if size == val.size {
                 return Ok(Response::builder()
                     .status(StatusCode::OK)
-                    .body(Body::empty())?);
+                    .body(empty())?);
             }
         }
 
         // Object doesn't exist or the size is incorrect.
         Ok(Response::builder()
             .status(StatusCode::NOT_FOUND)
-            .body(Body::empty())?)
+            .body(empty())?)
     }
 
     /// Batch API endpoint for the Git LFS server spec.
@@ -390,11 +466,11 @@ where
     )]
     async fn batch(
         storage: S,
-        req: Request<Body>,
+        req: Request<Incoming>,
         namespace: Namespace,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         // Get the host name and scheme.
-        let uri = req.base_uri().path_and_query("/").build().unwrap();
+        let uri = req.base_uri().path_and_query("/").build()?;
         let headers = req.headers().clone();
 
         match from_json::<lfs::BatchRequest>(req.into_body()).await {
@@ -420,15 +496,18 @@ where
                 });
 
                 let objects = future::try_join_all(objects).await?;
-                let response = lfs::BatchResponse {
-                    transfer: Some(lfs::Transfer::Basic),
-                    objects,
-                };
+                let mut transfer = Some(lfs::Transfer::Basic);
+                if let Some(transfers) = val.transfers {
+                    if transfers.contains(&lfs::Transfer::LfsRs) {
+                        transfer = Some(lfs::Transfer::LfsRs)
+                    }
+                }
+                let response = lfs::BatchResponse { transfer, objects };
 
                 Ok(Response::builder()
                     .status(StatusCode::OK)
                     .header(header::CONTENT_TYPE, "application/json")
-                    .body(into_json(&response)?)?)
+                    .body(full(into_json(&response)?))?)
             }
             Err(err) => {
                 let response = lfs::BatchResponseError {
@@ -440,16 +519,16 @@ where
 
                 Ok(Response::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(into_json(&response).unwrap())?)
+                    .body(full(into_json(&response)?))?)
             }
         }
     }
 
     async fn list_locks(
         locks: L,
-        req: Request<Body>,
+        req: Req,
         namespace: Namespace,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         let params: Option<HashMap<String, String>> =
             req.uri().query().map(|q| {
                 form_urlencoded::parse(q.as_bytes())
@@ -481,7 +560,7 @@ where
                         header::CONTENT_TYPE,
                         "application/vnd.git-lfs+json",
                     )
-                    .body(into_json(&resp).unwrap())?)
+                    .body(full(into_json(&resp)?))?)
             }
             Err(err) => {
                 let (status, body) = handle_lock_error_response(err);
@@ -498,10 +577,10 @@ where
 
     async fn create_lock(
         locks: L,
-        req: Request<Body>,
+        req: Req,
         namespace: Namespace,
         owner: String,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         let val: CreateLockRequest = from_json(req.into_body()).await?;
 
         match locks
@@ -526,7 +605,7 @@ where
                         header::CONTENT_TYPE,
                         "application/vnd.git-lfs+json",
                     )
-                    .body(into_json(&resp).unwrap())?)
+                    .body(full(into_json(&resp)?))?)
             }
             Err(err) => {
                 let (status, body) = handle_lock_error_response(err);
@@ -543,10 +622,10 @@ where
 
     async fn create_lock_batch(
         locks: L,
-        req: Request<Body>,
+        req: Req,
         namespace: Namespace,
         owner: String,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         let val: CreateLockBatchRequest = from_json(req.into_body()).await?;
 
         match locks
@@ -562,7 +641,7 @@ where
                         header::CONTENT_TYPE,
                         "application/vnd.git-lfs+json",
                     )
-                    .body(into_json(&resp).unwrap())?)
+                    .body(full(into_json(&resp)?))?)
             }
             Err(err) => {
                 let (status, body) = handle_lock_error_response(err);
@@ -579,10 +658,10 @@ where
 
     async fn list_locks_for_verification(
         locks: L,
-        req: Request<Body>,
+        req: Req,
         namespace: Namespace,
         owner: String,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         let val: VerifyLocksRequest = from_json(req.into_body()).await?;
         match locks
             .verify_locks(namespace.to_string(), owner, val.cursor, val.limit)
@@ -601,7 +680,7 @@ where
                         header::CONTENT_TYPE,
                         "application/vnd.git-lfs+json",
                     )
-                    .body(into_json(&resp).unwrap())?)
+                    .body(full(into_json(&resp)?))?)
             }
             Err(err) => {
                 let (status, body) = handle_lock_error_response(err);
@@ -618,11 +697,11 @@ where
 
     async fn release_lock(
         locks: L,
-        req: Request<Body>,
+        req: Req,
         namespace: Namespace,
         id: String,
         owner: String,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         let val: ReleaseLockRequest = from_json(req.into_body()).await?;
         match locks
             .release_lock(namespace.to_string(), owner, id, val.force)
@@ -646,7 +725,7 @@ where
                         header::CONTENT_TYPE,
                         "application/vnd.git-lfs+json",
                     )
-                    .body(into_json(&resp).unwrap())?)
+                    .body(full(into_json(&resp)?))?)
             }
             Err(err) => {
                 let (status, body) = handle_lock_error_response(err);
@@ -663,10 +742,10 @@ where
 
     async fn release_lock_batch(
         locks: L,
-        req: Request<Body>,
+        req: Req,
         namespace: Namespace,
         owner: String,
-    ) -> Result<Response<Body>, Error> {
+    ) -> Result<Response<BoxBody>, Error> {
         let val: ReleaseLockBatchRequest = from_json(req.into_body()).await?;
         match locks
             .release_locks(namespace.to_string(), owner, val.paths, val.force)
@@ -681,7 +760,7 @@ where
                         header::CONTENT_TYPE,
                         "application/vnd.git-lfs+json",
                     )
-                    .body(into_json(&resp).unwrap())?)
+                    .body(full(into_json(&resp)?))?)
             }
             Err(err) => {
                 let (status, body) = handle_lock_error_response(err);
@@ -759,7 +838,7 @@ where
             //
             // If the object does not exist, then we should return an upload
             // action.
-            let upload_expiry_secs = UPLOAD_EXPIRATION.as_secs() as i32;
+            let upload_expiry_secs = PRESIGNED_URL_EXPIRATION.as_secs() as i32;
             match size {
                 Some(size) => lfs::ResponseObject {
                     oid: object.oid,
@@ -768,47 +847,80 @@ where
                     authenticated: Some(true),
                     actions: None,
                 },
-                None => lfs::ResponseObject {
-                    oid: object.oid,
-                    size: object.size,
-                    error: None,
-                    authenticated: Some(true),
-                    actions: Some(lfs::Actions {
-                        download: None,
-                        upload: Some(lfs::Action {
-                            href: storage
-                                .upload_url(
-                                    &StorageKey::new(
-                                        namespace.clone(),
-                                        object.oid,
-                                    ),
-                                    UPLOAD_EXPIRATION,
-                                )
-                                .await
-                                .unwrap_or_else(|| {
-                                    format!(
-                                        "{}api/{}/object/{}",
-                                        uri, namespace, object.oid
-                                    )
-                                }),
-                            header: extract_auth_header(headers),
-                            expires_in: Some(upload_expiry_secs),
-                            expires_at: None,
-                        }),
-                        verify: Some(lfs::Action {
-                            href: format!(
-                                "{}api/{}/objects/verify",
-                                uri, namespace
+                None => {
+                    // If we're returning a pre-signed URL, don't also reflect
+                    // the auth header back to the client.
+                    let (upload_url, header) = match storage
+                        .upload_url(
+                            &StorageKey::new(namespace.clone(), object.oid),
+                            PRESIGNED_URL_EXPIRATION,
+                        )
+                        .await
+                    {
+                        Some(url) => (url, None),
+                        None => (
+                            format!(
+                                "{}api/{}/object/{}",
+                                uri, namespace, object.oid
                             ),
-                            header: extract_auth_header(headers),
-                            expires_in: None,
-                            expires_at: None,
+                            extract_auth_header(headers),
+                        ),
+                    };
+
+                    lfs::ResponseObject {
+                        oid: object.oid,
+                        size: object.size,
+                        error: None,
+                        authenticated: Some(true),
+                        actions: Some(lfs::Actions {
+                            download: None,
+                            upload: Some(lfs::Action {
+                                href: upload_url,
+                                header,
+                                expires_in: Some(upload_expiry_secs),
+                                expires_at: None,
+                            }),
+                            verify: Some(lfs::Action {
+                                href: format!(
+                                    "{}api/{}/objects/verify",
+                                    uri, namespace
+                                ),
+                                header: extract_auth_header(headers),
+                                expires_in: None,
+                                expires_at: None,
+                            }),
                         }),
-                    }),
-                },
+                    }
+                }
             }
         }
         lfs::Operation::Download => {
+            // If we're returning a pre-signed URL, don't also reflect
+            // the auth header back to the client.
+            let (download_url, header) = match storage
+                .download_url(
+                    &StorageKey::new(namespace.clone(), object.oid),
+                    PRESIGNED_URL_EXPIRATION,
+                )
+                .await
+            {
+                Some(url) => (url, None),
+                None => (
+                    storage
+                        .public_url(&StorageKey::new(
+                            namespace.clone(),
+                            object.oid,
+                        ))
+                        .unwrap_or_else(|| {
+                            format!(
+                                "{}api/{}/object/{}",
+                                uri, namespace, object.oid
+                            )
+                        }),
+                    extract_auth_header(headers),
+                ),
+            };
+
             // If the object does not exist, then we should return a 404 error
             // for this object.
             match size {
@@ -819,18 +931,8 @@ where
                     authenticated: Some(true),
                     actions: Some(lfs::Actions {
                         download: Some(lfs::Action {
-                            href: storage
-                                .public_url(&StorageKey::new(
-                                    namespace.clone(),
-                                    object.oid,
-                                ))
-                                .unwrap_or_else(|| {
-                                    format!(
-                                        "{}api/{}/object/{}",
-                                        uri, namespace, object.oid
-                                    )
-                                }),
-                            header: extract_auth_header(headers),
+                            href: download_url,
+                            header,
                             expires_in: None,
                             expires_at: None,
                         }),
@@ -878,14 +980,14 @@ fn extract_auth_header(
     }
 }
 
-impl<S, L> Service<Request<Body>> for App<S, L>
+impl<S, L> Service<Req> for App<S, L>
 where
     S: Storage + Clone + Send + Sync + 'static,
     S::Error: Into<Error> + 'static,
     L: LockStorage + Clone + Send + Sync + 'static,
     Error: From<S::Error>,
 {
-    type Response = Response<Body>;
+    type Response = Response<BoxBody>;
     type Error = Error;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -896,7 +998,44 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
+    #[cfg_attr(
+        feature = "otel",
+        instrument(
+            level = "info",
+            skip(self, req),
+            name = "http.request",
+            fields(
+                method = req.method().as_str(),
+                path = req.uri().path(),
+                query = req.uri().query().unwrap_or_default(),
+                headers
+            )
+        )
+    )]
+    fn call(&mut self, req: Request<Incoming>) -> Self::Future {
+        #[cfg(feature = "otel")]
+        {
+            let span = tracing::Span::current();
+
+            span.record(
+                "headers",
+                format!("{}", RedactedHeaders(req.headers().clone())),
+            );
+            let ctx = span.context();
+
+            if req.uri().path() == "/" {
+                Box::pin(future::ready(Self::index(req)).with_context(ctx))
+            } else if req.uri().path().starts_with("/api/") {
+                Box::pin(
+                    Self::api(self.storage.clone(), self.locks.clone(), req)
+                        .with_context(ctx),
+                )
+            } else {
+                Box::pin(future::ready(Self::not_found(req)).with_context(ctx))
+            }
+        }
+
+        #[cfg(not(feature = "otel"))]
         if req.uri().path() == "/" {
             Box::pin(future::ready(Self::index(req)))
         } else if req.uri().path().starts_with("/api/") {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,20 +1,31 @@
-use crate::error::Error;
-use crate::storage::Namespace;
-use base64::{engine::general_purpose, Engine as _};
 use core::task::{Context, Poll};
 use futures::future::BoxFuture;
+use std::{sync::Arc, time::Instant};
+
+use crate::storage::Namespace;
+use crate::util::{empty, full};
+use crate::{app::BoxBody, error::Error};
+
 use http::{self, header, HeaderMap, HeaderValue, StatusCode};
+use http_body_util::BodyExt;
 use hyper::{
-    self, body::Body, body::Buf, service::Service, Client, Request, Response,
+    self,
+    body::{Buf, Incoming},
+    Request, Response,
 };
 use hyper_tls::HttpsConnector;
+use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+use tower::Service;
+
+use base64::{engine::general_purpose, Engine as _};
 use linked_hash_map::LinkedHashMap;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::{sync::Arc, time::Instant};
+
 #[cfg(feature = "otel")]
-use tracing::instrument;
+use tracing::{instrument, Instrument as _};
+
 use tracing::{event, Level};
 
 type GithubAuthCache = Arc<RwLock<LinkedHashMap<String, AuthCacheEntry>>>;
@@ -55,7 +66,9 @@ pub struct UserRepoInfo {
     pub username: Option<String>,
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default,
+)]
 pub struct Permissions {
     #[serde(default)]
     pub admin: bool,
@@ -110,7 +123,7 @@ impl<S> Auth<S> {
                 event!(
                     Level::DEBUG,
                     message = "cache hit",
-                    key = key,
+                    key = format!("{}", &key[0..4]),
                     age = entry.timestamp.elapsed().as_secs()
                 );
 
@@ -120,7 +133,8 @@ impl<S> Auth<S> {
                 }
             }
 
-            let client = Client::builder().build(HttpsConnector::new());
+            let client = Client::builder(TokioExecutor::new())
+                .build(HttpsConnector::new());
 
             let url = format!(
                 "{}/repos/{}/{}",
@@ -133,14 +147,14 @@ impl<S> Auth<S> {
                 .header(header::ACCEPT, "application/vnd.github+json")
                 .header(header::AUTHORIZATION, auth)
                 .header(header::USER_AGENT, "rudolfs")
-                .body(Body::empty())?;
+                .body(empty())?;
 
             let res = client.request(req).await?;
 
             event!(Level::INFO, status = ?res.status(), url = %url);
 
             if res.status() == StatusCode::OK {
-                let body = hyper::body::aggregate(res).await?;
+                let body = res.collect().await?.aggregate();
                 let repository: Repository =
                     serde_json::from_reader(body.reader())?;
 
@@ -175,18 +189,19 @@ impl<S> Auth<S> {
         auth: &HeaderValue,
         server: &str,
     ) -> Result<Option<String>, Error> {
-        let client = Client::builder().build(HttpsConnector::new());
+        let client =
+            Client::builder(TokioExecutor::new()).build(HttpsConnector::new());
 
         let req = Request::get(format!("{}/user", server))
             .header(header::ACCEPT, "application/vnd.github+json")
             .header(header::AUTHORIZATION, auth)
             .header(header::USER_AGENT, "rudolfs")
-            .body(Body::empty())?;
+            .body(empty())?;
 
         let res = client.request(req).await?;
 
         if res.status() == StatusCode::OK {
-            let body = hyper::body::aggregate(res).await?;
+            let body = res.collect().await?.aggregate();
             let user_info: UserResp = serde_json::from_reader(body.reader())?;
 
             if let Some(username) = user_info.login {
@@ -206,9 +221,11 @@ impl<S> Auth<S> {
     }
 }
 
-impl<S> Service<Request<Body>> for Auth<S>
+type Req = Request<Incoming>;
+
+impl<S> Service<Req> for Auth<S>
 where
-    S: Service<Request<Body>, Response = Response<Body>>
+    S: Service<Req, Response = Response<BoxBody>>
         + Send
         + Sync
         + Clone
@@ -227,16 +244,35 @@ where
         self.service.poll_ready(cx)
     }
 
-    #[cfg_attr(feature = "otel", instrument(level = "debug", skip_all))]
-    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
-        event!(Level::DEBUG, path = ?req.uri().path());
+    #[cfg_attr(
+        feature = "otel",
+        instrument(
+            name = "auth.call",
+            level = "debug",
+            skip_all,
+            fields(authenticated, cache.entries, server)
+        )
+    )]
+    fn call(&mut self, mut req: Req) -> Self::Future {
+        log::debug!("checking auth for {}", &req.uri());
 
         if (!self.authenticated) || (!req.uri().path().starts_with("/api/")) {
+            log::trace!("skipping auth");
             return Box::pin(self.service.call(req));
         };
+        #[cfg(feature = "otel")]
+        tracing::Span::current().record("authenticated", true);
+
         let mut service = self.service.clone();
+
         let cache = Arc::clone(&self.cache);
+        #[cfg(feature = "otel")]
+        tracing::Span::current().record("cache.entries", cache.read().len());
+
         let server = self.server.clone();
+        #[cfg(feature = "otel")]
+        tracing::Span::current().record("server", &server);
+
         let auth_fut = async move {
             let mut parts =
                 req.uri().path().split('/').filter(|s| !s.is_empty());
@@ -252,7 +288,7 @@ where
                 _ => {
                     return Ok(Response::builder()
                         .status(StatusCode::BAD_REQUEST)
-                        .body(Body::from("Missing org/project in URL"))?)
+                        .body(full("Missing org/project in URL"))?)
                 }
             };
 
@@ -262,18 +298,21 @@ where
 
             // All endpoints require authentication, so return early
             // if we have no user or permissions.
-            #[allow(clippy::unnecessary_unwrap)]
             if user.is_none() || user.as_ref().unwrap().permissions.is_none() {
                 Ok(Response::builder()
                     .status(StatusCode::UNAUTHORIZED)
                     .header("Lfs-Authenticate", "Basic realm=\"GitHub\"")
-                    .body(Body::empty())?)
+                    .body(empty())?)
             } else {
                 let ext = req.extensions_mut();
                 ext.insert(user.unwrap());
                 service.call(req).await
             }
         };
+
+        #[cfg(feature = "otel")]
+        let auth_fut = auth_fut.instrument(tracing::info_span!("auth"));
+
         Box::pin(auth_fut)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 // Copyright (c) 2019 Jason White
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,23 +20,113 @@
 // SOFTWARE.
 use std::io;
 
-use derive_more::{Display, From};
-
 use crate::sha256::{Sha256Error, Sha256VerifyError};
 use crate::storage::{self, Storage};
 
 // Define a type so we can return multiple types of errors
-#[derive(Debug, From, Display)]
+#[derive(Debug)]
 pub enum Error {
     Io(io::Error),
     Http(http::Error),
     Hyper(hyper::Error),
+    HyperUtil(hyper_util::client::legacy::Error),
     Json(serde_json::Error),
     Sha256(Sha256Error),
     Sha256Verify(Sha256VerifyError),
-    S3(storage::S3Error),
+    S3(Box<storage::S3Error>),
     S3DiskCache(<storage::S3DiskCache as Storage>::Error),
     Askama(askama::Error),
+    Infallible(std::convert::Infallible),
 }
 
 impl std::error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::Io(err)
+    }
+}
+
+impl From<http::Error> for Error {
+    fn from(err: http::Error) -> Self {
+        Error::Http(err)
+    }
+}
+
+impl From<hyper::Error> for Error {
+    fn from(err: hyper::Error) -> Self {
+        Error::Hyper(err)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(err: hyper_util::client::legacy::Error) -> Self {
+        Error::HyperUtil(err)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Error::Json(err)
+    }
+}
+
+impl From<Sha256Error> for Error {
+    fn from(err: Sha256Error) -> Self {
+        Error::Sha256(err)
+    }
+}
+
+impl From<Sha256VerifyError> for Error {
+    fn from(err: Sha256VerifyError) -> Self {
+        Error::Sha256Verify(err)
+    }
+}
+
+impl From<storage::S3Error> for Error {
+    fn from(err: storage::S3Error) -> Self {
+        Error::S3(Box::new(err))
+    }
+}
+
+impl From<<storage::S3DiskCache as Storage>::Error> for Error {
+    fn from(err: <storage::S3DiskCache as Storage>::Error) -> Self {
+        Error::S3DiskCache(err)
+    }
+}
+
+impl From<askama::Error> for Error {
+    fn from(err: askama::Error) -> Self {
+        Error::Askama(err)
+    }
+}
+
+impl From<std::convert::Infallible> for Error {
+    fn from(err: std::convert::Infallible) -> Self {
+        Error::Infallible(err)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Io(error) => write!(f, "I/O error: {}", error),
+            Error::Http(error) => write!(f, "HTTP error: {}", error),
+            Error::Hyper(error) => write!(f, "Hyper error: {}", error),
+            Error::HyperUtil(error) => write!(f, "HyperUtil error: {}", error),
+            Error::Json(error) => write!(f, "JSON error: {}", error),
+            Error::Sha256(sha256_error) => {
+                write!(f, "SHA-256 error: {}", sha256_error)
+            }
+            Error::Sha256Verify(sha256_verify_error) => {
+                write!(f, "SHA-256 verification error: {}", sha256_verify_error)
+            }
+            Error::S3(error) => write!(f, "S3 error: {}", error),
+            Error::S3DiskCache(_) => write!(f, "S3 disk cache error"),
+            Error::Askama(error) => write!(f, "Askama error: {}", error),
+            Error::Infallible(infallible) => {
+                write!(f, "Infallible error: {}", infallible)
+            }
+        }
+    }
+}

--- a/src/init_tracing.rs
+++ b/src/init_tracing.rs
@@ -1,7 +1,6 @@
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::KeyValue;
-// use opentelemetry_sdk::logs::LoggerProvider;
 use tracing_opentelemetry::{MetricsLayer, OpenTelemetryLayer};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::EnvFilter;

--- a/src/init_tracing.rs
+++ b/src/init_tracing.rs
@@ -25,7 +25,8 @@ pub struct OtelGuard {
     meter_provider: SdkMeterProvider,
 }
 
-// Create a Resource that captures information about the entity for which telemetry is recorded.
+// Create a Resource that captures information about the entity for which
+// telemetry is recorded.
 fn resource() -> Resource {
     Resource::from_schema_url(
         [

--- a/src/init_tracing.rs
+++ b/src/init_tracing.rs
@@ -1,0 +1,135 @@
+use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::KeyValue;
+// use opentelemetry_sdk::logs::LoggerProvider;
+use tracing_opentelemetry::{MetricsLayer, OpenTelemetryLayer};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Registry;
+
+use tracing_log::LogTracer;
+
+use opentelemetry_sdk::{
+    metrics::{MeterProviderBuilder, PeriodicReader, SdkMeterProvider},
+    runtime,
+    trace::{RandomIdGenerator, Sampler, TracerProvider},
+    Resource,
+};
+
+use opentelemetry_semantic_conventions::{
+    attribute::{SERVICE_NAME, SERVICE_VERSION},
+    SCHEMA_URL,
+};
+
+pub struct OtelGuard {
+    tracer_provider: TracerProvider,
+    meter_provider: SdkMeterProvider,
+}
+
+// Create a Resource that captures information about the entity for which telemetry is recorded.
+fn resource() -> Resource {
+    Resource::from_schema_url(
+        [
+            KeyValue::new(SERVICE_NAME, env!("CARGO_PKG_NAME")),
+            KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+        ],
+        SCHEMA_URL,
+    )
+}
+
+impl Drop for OtelGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self.tracer_provider.shutdown() {
+            eprintln!("{err:?}");
+        }
+        if let Err(err) = self.meter_provider.shutdown() {
+            eprintln!("{err:?}");
+        }
+    }
+}
+
+// Construct MeterProvider for MetricsLayer
+fn init_meter_provider() -> SdkMeterProvider {
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_tonic()
+        .with_temporality(opentelemetry_sdk::metrics::Temporality::default())
+        .build()
+        .unwrap();
+
+    let reader = PeriodicReader::builder(exporter, runtime::Tokio)
+        .with_interval(std::time::Duration::from_secs(30))
+        .build();
+
+    // For debugging in development
+    let stdout_reader = PeriodicReader::builder(
+        opentelemetry_stdout::MetricExporter::default(),
+        runtime::Tokio,
+    )
+    .build();
+
+    let meter_provider = MeterProviderBuilder::default()
+        .with_resource(resource())
+        .with_reader(reader)
+        .with_reader(stdout_reader)
+        .build();
+
+    global::set_meter_provider(meter_provider.clone());
+
+    meter_provider
+}
+
+// Construct TracerProvider for OpenTelemetryLayer
+fn init_tracer_provider() -> TracerProvider {
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .build()
+        .unwrap();
+
+    TracerProvider::builder()
+        // Customize sampling strategy
+        .with_sampler(Sampler::ParentBased(Box::new(
+            Sampler::TraceIdRatioBased(1.0),
+        )))
+        // If export trace to AWS X-Ray, you can use XrayIdGenerator
+        .with_id_generator(RandomIdGenerator::default())
+        .with_resource(resource())
+        .with_batch_exporter(exporter, runtime::Tokio)
+        .build()
+}
+
+pub fn setup_tracing(_level: log::LevelFilter) -> OtelGuard {
+    // Setup tracing-log to emit log records as tracing spans
+    LogTracer::init().expect("Failed to set default logger");
+
+    let tracer_provider = init_tracer_provider();
+    let meter_provider = init_meter_provider();
+
+    let tracer = tracer_provider.tracer(env!("CARGO_PKG_NAME"));
+
+    // Create a new OpenTelemetry logging pipeline that prints to stdout
+    // let exporter = opentelemetry_stdout::LogExporter::default();
+    // let logs_provider = LoggerProvider::builder()
+    //     .with_simple_exporter(exporter)
+    //     .build();
+
+    let env_filter = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .unwrap();
+
+    // Use the tracing subscriber `Registry`, or any other subscriber
+    // that impls `LookupSpan`
+    let subscriber = Registry::default()
+        .with(tracing_subscriber::fmt::layer())
+        // .with(otel_logs_layer)
+        .with(OpenTelemetryLayer::new(tracer))
+        .with(MetricsLayer::new(meter_provider.clone()))
+        .with(env_filter);
+
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Failed to set default tracing subscriber");
+
+    OtelGuard {
+        tracer_provider,
+        meter_provider,
+    }
+}

--- a/src/init_tracing.rs
+++ b/src/init_tracing.rs
@@ -90,7 +90,6 @@ fn init_tracer_provider() -> TracerProvider {
         .with_sampler(Sampler::ParentBased(Box::new(
             Sampler::TraceIdRatioBased(1.0),
         )))
-        // If export trace to AWS X-Ray, you can use XrayIdGenerator
         .with_id_generator(RandomIdGenerator::default())
         .with_resource(resource())
         .with_batch_exporter(exporter, runtime::Tokio)
@@ -106,18 +105,10 @@ pub fn setup_tracing(_level: log::LevelFilter) -> OtelGuard {
 
     let tracer = tracer_provider.tracer(env!("CARGO_PKG_NAME"));
 
-    // Create a new OpenTelemetry logging pipeline that prints to stdout
-    // let exporter = opentelemetry_stdout::LogExporter::default();
-    // let logs_provider = LoggerProvider::builder()
-    //     .with_simple_exporter(exporter)
-    //     .build();
-
     let env_filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))
         .unwrap();
 
-    // Use the tracing subscriber `Registry`, or any other subscriber
-    // that impls `LookupSpan`
     let subscriber = Registry::default()
         .with(tracing_subscriber::fmt::layer())
         // .with(otel_logs_layer)

--- a/src/lfs.rs
+++ b/src/lfs.rs
@@ -33,11 +33,12 @@ pub enum Operation {
 }
 
 /// A transfer adaptor.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Transfer {
     /// Basic transfer adapter.
     Basic,
+    LfsRs,
 
     LfsStandaloneFile,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,52 +31,37 @@ mod sha256;
 mod storage;
 mod util;
 
+use futures::future::{BoxFuture, Either, Future, TryFutureExt};
 use parking_lot::RwLock;
-use std::convert::Infallible;
-use std::net::SocketAddr;
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::{
+    net::SocketAddr, path::PathBuf, pin::pin, sync::Arc, time::Duration,
+};
+
+use hyper_util::service::TowerToHyperService;
+use tokio::net::TcpListener;
+use tower::ServiceBuilder;
 
 use auth::Auth;
-use futures::future::{self, Either, Future, TryFutureExt};
-use hyper::{
-    self,
-    server::conn::{AddrIncoming, AddrStream},
-    service::make_service_fn,
-};
 use linked_hash_map::LinkedHashMap;
 
 use crate::app::App;
 use crate::error::Error;
-#[cfg(feature = "dynamodb")]
-pub use crate::locks::DynamoLs;
-#[cfg(feature = "redis")]
-pub use crate::locks::RedisLs;
 pub use crate::locks::{
     CreateLockBatchRequest, LocalLs, LockBatch, LockBatchOuter, LockFailure,
     LockStorage, NoneLs, ReleaseLockBatchRequest,
 };
 use crate::logger::Logger;
 use crate::storage::{Cached, Disk, Encrypted, Retrying, Storage, Verify, S3};
-pub use crate::util::{from_json, into_json};
+pub use crate::util::{empty, from_json, full, into_json};
+
+#[cfg(feature = "dynamodb")]
+pub use crate::locks::DynamoLs;
+
+#[cfg(feature = "redis")]
+pub use crate::locks::RedisLs;
 
 #[cfg(feature = "faulty")]
 use crate::storage::Faulty;
-
-/// Represents a running LFS server.
-pub trait Server: Future<Output = hyper::Result<()>> {
-    /// Returns the local address this server is bound to.
-    fn addr(&self) -> SocketAddr;
-}
-
-impl<S, E> Server for hyper::Server<AddrIncoming, S, E>
-where
-    hyper::Server<AddrIncoming, S, E>: Future<Output = hyper::Result<()>>,
-{
-    fn addr(&self) -> SocketAddr {
-        self.local_addr()
-    }
-}
 
 #[derive(Debug)]
 pub struct Cache {
@@ -99,6 +84,7 @@ pub struct S3ServerBuilder {
     key: Option<[u8; 32]>,
     prefix: Option<String>,
     cdn: Option<String>,
+    s3_accelerate: bool,
     cache: Option<Cache>,
     authenticated: bool,
     authentication_server: Option<String>,
@@ -110,6 +96,7 @@ impl S3ServerBuilder {
             bucket,
             prefix: None,
             cdn: None,
+            s3_accelerate: false,
             key,
             cache: None,
             authenticated: false,
@@ -142,6 +129,12 @@ impl S3ServerBuilder {
         self
     }
 
+    /// Sets the flag to use S3 accelerate endpoints.
+    pub fn s3_accelerate(&mut self, s3_accelerate: bool) -> &mut Self {
+        self.s3_accelerate = s3_accelerate;
+        self
+    }
+
     /// Sets the cache to use. If not specified, then no local disk cache is
     /// used. All objects will get sent directly to S3.
     pub fn cache(&mut self, cache: Cache) -> &mut Self {
@@ -170,8 +163,10 @@ impl S3ServerBuilder {
         mut self,
         addr: SocketAddr,
         locks: impl LockStorage + Send + Sync + 'static,
-    ) -> Result<Box<dyn Server + Unpin + Send>, Box<dyn std::error::Error>>
-    {
+    ) -> Result<
+        (BoxFuture<'static, Result<(), Error>>, SocketAddr),
+        Box<dyn std::error::Error>,
+    > {
         let prefix = self.prefix.unwrap_or_else(|| String::from("lfs"));
 
         if self.cdn.is_some() {
@@ -188,7 +183,7 @@ impl S3ServerBuilder {
             }
         }
 
-        let s3 = S3::new(self.bucket, prefix, self.cdn)
+        let s3 = S3::new(self.bucket, prefix, self.cdn, self.s3_accelerate)
             .map_err(Error::from)
             .await?;
 
@@ -217,13 +212,16 @@ impl S3ServerBuilder {
                         Either::Right(Verify::new(cache))
                     }
                 });
-                Ok(Box::new(spawn_server(
+                let (fut, addr) = spawn_server(
                     storage,
                     locks,
-                    &addr,
+                    addr,
                     self.authenticated,
                     self.authentication_server,
-                )))
+                )
+                .await?;
+
+                Ok((Box::pin(fut), addr))
             }
             None => {
                 let storage = Verify::new(match self.key {
@@ -232,13 +230,16 @@ impl S3ServerBuilder {
                     }
                     None => Either::Right(Verify::new(s3)),
                 });
-                Ok(Box::new(spawn_server(
+                let (fut, addr) = spawn_server(
                     storage,
                     locks,
-                    &addr,
+                    addr,
                     self.authenticated,
                     self.authentication_server,
-                )))
+                )
+                .await?;
+
+                Ok((Box::pin(fut), addr))
             }
         }
     }
@@ -250,9 +251,9 @@ impl S3ServerBuilder {
         addr: SocketAddr,
         lock: impl LockStorage + Send + Sync + 'static,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let server = self.spawn(addr, lock).await?;
+        let (server, addr) = self.spawn(addr, lock).await?;
 
-        log::info!("Listening on {}", server.addr());
+        log::info!("Listening on {}", addr);
 
         server.await?;
         Ok(())
@@ -318,7 +319,10 @@ impl LocalServerBuilder {
         self,
         addr: SocketAddr,
         locks: impl LockStorage + Send + Sync + 'static,
-    ) -> Result<impl Server, Box<dyn std::error::Error>> {
+    ) -> Result<
+        (BoxFuture<'static, Result<(), Error>>, SocketAddr),
+        Box<dyn std::error::Error>,
+    > {
         let storage = Disk::new(self.path).map_err(Error::from).await?;
         let storage = Verify::new(match self.key {
             Some(key) => {
@@ -332,13 +336,16 @@ impl LocalServerBuilder {
 
         log::info!("Local disk storage initialized.");
 
-        Ok(spawn_server(
+        let (fut, addr) = spawn_server(
             storage,
             locks,
-            &addr,
+            addr,
             self.authenticated,
             self.authentication_server,
-        ))
+        )
+        .await?;
+
+        Ok((Box::pin(fut), addr))
     }
 
     /// Spawns the server and runs it to completion. This will run forever
@@ -348,22 +355,22 @@ impl LocalServerBuilder {
         addr: SocketAddr,
         locks: impl LockStorage + Send + Sync + 'static,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let server = self.spawn(addr, locks).await?;
+        let (server, addr) = self.spawn(addr, locks).await?;
 
-        log::info!("Listening on {}", server.addr());
+        log::info!("Listening on {}", addr);
 
         server.await?;
         Ok(())
     }
 }
 
-fn spawn_server<S, L>(
+async fn spawn_server<S, L>(
     storage: S,
     locks: L,
-    addr: &SocketAddr,
+    addr: SocketAddr,
     authenticated: bool,
     authentication_server: Option<String>,
-) -> impl Server
+) -> Result<(impl Future<Output = Result<(), Error>>, SocketAddr), Error>
 where
     S: Storage + Send + Sync + 'static,
     S::Error: Into<Error>,
@@ -374,23 +381,83 @@ where
     let locks = Arc::new(locks);
     let cache = Arc::new(RwLock::new(LinkedHashMap::new()));
 
-    let new_service = make_service_fn(move |socket: &AddrStream| {
-        // Create our app.
-        let service = App::new(storage.clone(), locks.clone());
-        let cache = Arc::clone(&cache);
+    let listener = TcpListener::bind(addr).await?;
+    let addr = listener.local_addr()?;
+    let server = hyper_util::server::conn::auto::Builder::new(
+        hyper_util::rt::TokioExecutor::new(),
+    );
 
-        // Wrap the app in an auth middleware. If not authenticated, wrapper
-        // acts as a passthrough service.
-        let auth = Auth::new(
-            service,
-            cache,
-            authenticated,
-            authentication_server.clone(),
-        );
+    Ok((
+        async move {
+            let graceful =
+                hyper_util::server::graceful::GracefulShutdown::new();
+            let mut ctrl_c = pin!(tokio::signal::ctrl_c());
+            loop {
+                tokio::select! {
+                    conn = listener.accept() => {
+                        let (stream, peer_addr) = match conn {
+                            Ok(conn) => conn,
+                            Err(e) => {
+                                log::error!("accept error: {}", e);
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                continue;
+                            }
+                        };
+                        // Create our app.
+                        let app = App::new(storage.clone(), locks.clone());
+                        let cache = Arc::clone(&cache);
+                        stream.set_nodelay(true)?;
 
-        // Add logging middleware
-        future::ok::<_, Infallible>(Logger::new(socket.remote_addr(), auth))
-    });
+                        // Wrap the app in an auth middleware. If not authenticated, wrapper
+                        // acts as a passthrough service.
+                        let auth = Auth::new(
+                            app,
+                            cache,
+                            authenticated,
+                            authentication_server.clone(),
+                        );
 
-    hyper::Server::bind(addr).serve(new_service)
+                        // Add logging middleware
+                        let logger = Logger::new(peer_addr, auth);
+                        let svc = TowerToHyperService::new(logger);
+
+                        let service = ServiceBuilder::new()
+                            .service(svc);
+
+                        let stream = hyper_util::rt::TokioIo::new(Box::pin(stream));
+
+                        let conn = server.serve_connection(stream, service);
+
+                        let conn = graceful.watch(conn.into_owned());
+
+                        let handler = async move {
+                            if let Err(err) = conn.await {
+                                log::error!("connection error: {}", err);
+                            }
+                            log::debug!("connection dropped: {}", peer_addr);
+                        };
+                        tokio::spawn(handler);
+                    },
+
+                    _ = ctrl_c.as_mut() => {
+                        drop(listener);
+                        log::info!("Ctrl-C received, starting shutdown");
+                            break;
+                    }
+                }
+            }
+
+            tokio::select! {
+                _ = graceful.shutdown() => {
+                    log::info!("Gracefully shutdown!");
+                    Ok(())
+                },
+                _ = tokio::time::sleep(Duration::from_secs(10)) => {
+                    log::info!("Waited 10 seconds for graceful shutdown, aborting...");
+                    Ok(())
+                }
+            }
+        },
+        addr,
+    ))
 }

--- a/src/locks/mod.rs
+++ b/src/locks/mod.rs
@@ -18,14 +18,22 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use thiserror::Error;
 
+#[allow(dead_code)]
 #[derive(Error, Debug)]
 pub enum LockStoreError {
     #[error("already created lock")]
     CreateConflict(Lock),
     #[error("not implemented")]
     NotImplemented,
-    #[error("internal server error")]
-    InternalServerError,
+    #[error("internal server error: {0}")]
+    InternalServerError(String),
+    #[error("deleting key that does not exist: {0}")]
+    DeleteNotFound(String),
+    #[error("lock not found: {0}")]
+    LockNotFound(String),
+    #[cfg(feature = "redis")]
+    #[error("redis error: {0}")]
+    RedisError(#[from] redis::RedisError),
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -25,9 +25,13 @@ use std::time::Instant;
 
 use futures::future::{BoxFuture, FutureExt};
 use humantime::format_duration;
-use hyper::{service::Service, Body, Request, Response};
+use hyper::{body::Incoming, Request, Response};
+use tower::Service;
+
+use crate::app::BoxBody;
 
 /// Wraps a service to provide logging on both the request and the response.
+#[derive(Debug, Clone)]
 pub struct Logger<S> {
     remote_addr: SocketAddr,
     service: S,
@@ -42,9 +46,9 @@ impl<S> Logger<S> {
     }
 }
 
-impl<S> Service<Request<Body>> for Logger<S>
+impl<S> Service<Request<Incoming>> for Logger<S>
 where
-    S: Service<Request<Body>, Response = Response<Body>>,
+    S: Service<Request<Incoming>, Response = Response<BoxBody>>,
     S::Future: Send + 'static,
     S::Error: fmt::Display + Send + 'static,
 {
@@ -59,7 +63,7 @@ where
         self.service.poll_ready(cx)
     }
 
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
+    fn call(&mut self, req: Request<Incoming>) -> Self::Future {
         let method = req.method().clone();
         let uri = req.uri().clone();
         let remote_addr = self.remote_addr;
@@ -69,16 +73,18 @@ where
         Box::pin(self.service.call(req).inspect(
             move |response| match response {
                 Ok(response) => log::info!(
-                    "[{}] {} {} - {} ({})",
+                    "[{}:{}] {} {} - {} ({})",
                     remote_addr.ip(),
+                    remote_addr.port(),
                     method,
                     uri,
                     response.status(),
                     format_duration(start.elapsed()),
                 ),
                 Err(err) => log::error!(
-                    "[{}] {} {} - {} ({})",
+                    "[{}:{}] {} {} - {} ({})",
                     remote_addr.ip(),
+                    remote_addr.port(),
                     method,
                     uri,
                     err,

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,8 @@ use lfs_rs::RedisLs;
 mod init_tracing;
 #[cfg(feature = "otel")]
 use init_tracing::setup_tracing;
+#[cfg(feature = "otel")]
+use tracing::{field, instrument, span};
 
 // Additional help to append to the end when `--help` is specified.
 static AFTER_HELP: &str = include_str!("help.md");
@@ -63,7 +65,7 @@ enum Backend {
     Local(LocalArgs),
 }
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 struct GlobalArgs {
     /// The host or address to listen on. If this is not specified, then
     /// `0.0.0.0` is used where the port can be specified with `--port`
@@ -107,7 +109,7 @@ fn from_hex(s: &str) -> Result<[u8; 32], hex::FromHexError> {
     FromHex::from_hex(s)
 }
 
-#[derive(Parser, Clone)]
+#[derive(Parser, Clone, Debug)]
 enum LockBackend {
     /// Starts the server with DynamoDB as the lock backend.
     #[cfg(feature = "dynamodb")]
@@ -142,7 +144,7 @@ impl From<&str> for LockBackend {
     }
 }
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 pub struct LockArgs {
     /// Locking backend to use
     #[clap(
@@ -190,7 +192,7 @@ pub struct LockArgs {
     dynamodb_table: Option<String>,
 }
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 struct S3Args {
     /// Amazon S3 bucket to use.
     #[clap(long, env = "RUDOLFS_S3_BUCKET")]
@@ -204,6 +206,11 @@ struct S3Args {
     /// prefixed with this URL.
     #[clap(long = "cdn", env = "RUDOLFS_S3_CDN")]
     cdn: Option<String>,
+
+    /// Use AWS S3 Transfer Acceleration endpoints. The endpoint must have
+    /// transfer acceleration enabled.
+    #[clap(long = "s3ta", env = "RUDOLFS_S3TA")]
+    s3_accelerate: bool,
 }
 
 #[derive(Parser)]
@@ -231,6 +238,10 @@ impl Args {
         #[cfg(feature = "otel")]
         let _guard = setup_tracing(self.global.log_level);
 
+        #[cfg(feature = "otel")]
+        let server_span =
+            span!(tracing::Level::INFO, "server", local_addr = field::Empty);
+
         log::info!("Starting server...");
 
         // Find a socket address to bind to. This will resolve domain names.
@@ -241,6 +252,9 @@ impl Args {
                 .unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 8080))),
             None => SocketAddr::from(([0, 0, 0, 0], self.global.port)),
         };
+
+        #[cfg(feature = "otel")]
+        server_span.record("local_addr", addr.to_string());
 
         log::info!("Initializing storage...");
 
@@ -258,6 +272,10 @@ impl Args {
 }
 
 impl S3Args {
+    #[cfg_attr(
+        feature = "otel",
+        instrument(level = "info", name = "s3args.run")
+    )]
     async fn run(
         self,
         addr: SocketAddr,
@@ -270,6 +288,10 @@ impl S3Args {
 
         if let Some(cdn) = self.cdn {
             builder.cdn(cdn);
+        }
+
+        if self.s3_accelerate {
+            builder.s3_accelerate(self.s3_accelerate);
         }
 
         if let Some(cache_dir) = global_args.cache_dir {
@@ -306,6 +328,10 @@ impl S3Args {
 }
 
 impl LocalArgs {
+    #[cfg_attr(
+        feature = "otel",
+        instrument(level = "info", skip(self), name = "http.request")
+    )]
     async fn run(
         self,
         addr: SocketAddr,

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -32,7 +32,7 @@ use serde::{
     Deserialize, Serialize,
 };
 
-use generic_array::{typenum, GenericArray};
+use sha2::digest::generic_array::{typenum, GenericArray};
 use sha2::{self, Digest};
 
 /// An error associated with parsing a SHA256.

--- a/src/storage/cached.rs
+++ b/src/storage/cached.rs
@@ -397,4 +397,12 @@ where
     ) -> Option<String> {
         self.storage.upload_url(key, expires_in).await
     }
+
+    async fn download_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.storage.download_url(key, expires_in).await
+    }
 }

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -261,6 +261,14 @@ impl Storage for Backend {
     ) -> Option<String> {
         None
     }
+
+    async fn download_url(
+        &self,
+        _key: &StorageKey,
+        _expires_in: Duration,
+    ) -> Option<String> {
+        None
+    }
 }
 
 /// A simple bytes codec that keeps track of its length.

--- a/src/storage/encrypt.rs
+++ b/src/storage/encrypt.rs
@@ -134,4 +134,12 @@ where
     ) -> Option<String> {
         self.storage.upload_url(key, expires_in).await
     }
+
+    async fn download_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.storage.download_url(key, expires_in).await
+    }
 }

--- a/src/storage/faulty.rs
+++ b/src/storage/faulty.rs
@@ -129,10 +129,18 @@ where
     ) -> Option<String> {
         self.storage.upload_url(key, expires_in).await
     }
+
+    async fn download_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.storage.download_url(key, expires_in).await
+    }
 }
 
 #[derive(Debug, Display)]
-#[display(fmt = "injected fault")]
+#[display("injected fault")]
 pub struct FaultError;
 
 impl std::error::Error for FaultError {}

--- a/src/storage/retrying.rs
+++ b/src/storage/retrying.rs
@@ -103,4 +103,12 @@ where
     ) -> Option<String> {
         self.storage.upload_url(key, expires_in).await
     }
+
+    async fn download_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.storage.download_url(key, expires_in).await
+    }
 }

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Jason White
+// Copyright (c) 2020 Jason White
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,43 +18,41 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 use async_trait::async_trait;
-use backoff::future::retry;
-use backoff::ExponentialBackoff;
-use bytes::{Bytes, BytesMut};
-use derive_more::{Display, From};
-use futures::{stream, stream::TryStreamExt};
-use http::{HeaderMap, StatusCode};
-use rusoto_core::request::BufferedHttpResponse;
-use rusoto_core::{HttpClient, Region, RusotoError};
-use rusoto_credential::{
-    AutoRefreshingProvider, DefaultCredentialsProvider, ProvideAwsCredentials,
-};
-use rusoto_s3::{
-    CompleteMultipartUploadError, CompleteMultipartUploadRequest,
-    CompletedMultipartUpload, CompletedPart, CreateMultipartUploadError,
-    CreateMultipartUploadRequest, GetObjectError, GetObjectRequest,
-    HeadBucketError, HeadBucketRequest, HeadObjectError, HeadObjectRequest,
-    PutObjectError, PutObjectRequest, S3Client, StreamingBody, UploadPartError,
-    UploadPartRequest, S3,
-};
-use rusoto_sts::WebIdentityProvider;
+use aws_config::Region;
+use aws_sdk_s3::config::http::HttpResponse;
+use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadError;
+use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadError;
+use aws_sdk_s3::operation::get_object::GetObjectError;
+use aws_sdk_s3::operation::head_bucket::HeadBucketError;
+use aws_sdk_s3::operation::head_object::HeadObjectError;
+use aws_sdk_s3::operation::put_object::PutObjectError;
+use aws_sdk_s3::operation::upload_part::UploadPartError;
+use aws_sdk_s3::presigning::PresigningConfig;
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+use aws_sdk_s3::Client;
+use aws_sdk_s3::Error as S3Error;
+use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::byte_stream::ByteStream;
+use bytes::BytesMut;
+use futures::{stream, TryStreamExt};
 use tokio::io::AsyncReadExt;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
+use tokio_util::io::ReaderStream;
 
 use super::{LFSObject, Storage, StorageKey, StorageStream};
-use rusoto_s3::util::{PreSignedRequest, PreSignedRequestOption};
+use derive_more::{Display, From};
 use std::time::Duration;
-
-type BoxedCredentialProvider =
-    Box<dyn ProvideAwsCredentials + Send + Sync + 'static>;
 
 #[derive(Debug, From, Display)]
 pub enum Error {
-    Get(RusotoError<GetObjectError>),
-    Put(RusotoError<PutObjectError>),
-    CreateMultipart(RusotoError<CreateMultipartUploadError>),
-    Upload(RusotoError<UploadPartError>),
-    CompleteMultipart(RusotoError<CompleteMultipartUploadError>),
-    Head(RusotoError<HeadObjectError>),
+    Get(GetObjectError),
+    Put(PutObjectError),
+    CreateMultipart(CreateMultipartUploadError),
+    Upload(UploadPartError),
+    CompleteMultipart(CompleteMultipartUploadError),
+    Head(HeadObjectError),
+    Generic(String),
 
     Stream(std::io::Error),
 
@@ -63,10 +61,49 @@ pub enum Error {
 
     /// The uploaded object is too large.
     TooLarge(u64),
+}
 
-    Tls(rusoto_core::request::TlsError),
+impl From<S3Error> for Error {
+    fn from(value: S3Error) -> Self {
+        let x = value;
+        Self::Generic(x.to_string())
+    }
+}
 
-    Credentials(rusoto_credential::CredentialsError),
+impl From<SdkError<GetObjectError, HttpResponse>> for Error {
+    fn from(err: SdkError<GetObjectError, HttpResponse>) -> Self {
+        Error::Get(err.into_service_error())
+    }
+}
+
+impl From<SdkError<PutObjectError, HttpResponse>> for Error {
+    fn from(err: SdkError<PutObjectError, HttpResponse>) -> Self {
+        Error::Put(err.into_service_error())
+    }
+}
+
+impl From<SdkError<CreateMultipartUploadError, HttpResponse>> for Error {
+    fn from(err: SdkError<CreateMultipartUploadError, HttpResponse>) -> Self {
+        Error::CreateMultipart(err.into_service_error())
+    }
+}
+
+impl From<SdkError<UploadPartError, HttpResponse>> for Error {
+    fn from(err: SdkError<UploadPartError, HttpResponse>) -> Self {
+        Error::Upload(err.into_service_error())
+    }
+}
+
+impl From<SdkError<CompleteMultipartUploadError, HttpResponse>> for Error {
+    fn from(err: SdkError<CompleteMultipartUploadError, HttpResponse>) -> Self {
+        Error::CompleteMultipart(err.into_service_error())
+    }
+}
+
+impl From<SdkError<HeadObjectError, HttpResponse>> for Error {
+    fn from(err: SdkError<HeadObjectError, HttpResponse>) -> Self {
+        Error::Head(err.into_service_error())
+    }
 }
 
 impl ::std::error::Error for Error {}
@@ -101,37 +138,36 @@ impl InitError {
     }
 }
 
-impl From<RusotoError<HeadBucketError>> for InitError {
-    fn from(err: RusotoError<HeadBucketError>) -> Self {
+impl From<HeadBucketError> for InitError {
+    fn from(err: HeadBucketError) -> Self {
         match err {
-            RusotoError::Credentials(_) => InitError::Credentials,
-            RusotoError::Unknown(r) => {
-                // Rusoto really sucks at correctly reporting errors.
-                // Lets work around that here.
-                match r.status {
-                    StatusCode::NOT_FOUND => InitError::Bucket,
-                    StatusCode::FORBIDDEN => InitError::Credentials,
-                    _ => InitError::Other(format!(
-                        "S3 returned HTTP status {}",
-                        r.status
-                    )),
-                }
-            }
-            RusotoError::Service(HeadBucketError::NoSuchBucket(_)) => {
-                InitError::Bucket
-            }
+            HeadBucketError::NotFound(_not_found) => InitError::Bucket,
             x => InitError::Other(x.to_string()),
+            // RusotoError::Credentials(_) => InitError::Credentials,
+            // RusotoError::Unknown(r) => {
+            //     // Rusoto really sucks at correctly reporting errors.
+            //     // Lets work around that here.
+            //     match r.status {
+            //         StatusCode::NOT_FOUND => InitError::Bucket,
+            //         StatusCode::FORBIDDEN => InitError::Credentials,
+            //         _ => InitError::Other(format!(
+            //             "S3 returned HTTP status {}",
+            //             r.status
+            //         )),
+            //     }
+            // }
+            // RusotoError::Service(HeadBucketError::NoSuchBucket(_)) => {
+            //     InitError::Bucket
+            // }
+            // x => InitError::Other(x.to_string()),
         }
     }
 }
 
 /// Amazon S3 storage backend.
-pub struct Backend<C = S3Client> {
+pub struct Backend {
     /// S3 client.
-    client: C,
-
-    // AWS Credentials. Used for signing URLs.
-    credential_provider: BoxedCredentialProvider,
+    client: Client,
 
     /// Name of the bucket to use.
     bucket: String,
@@ -141,8 +177,6 @@ pub struct Backend<C = S3Client> {
 
     /// URL for the CDN. Example: https://lfscdn.myawesomegit.com
     cdn: Option<String>,
-
-    region: Region,
 }
 
 impl Backend {
@@ -156,141 +190,99 @@ impl Backend {
             prefix.pop();
         }
 
-        let region = if let Ok(endpoint) = std::env::var("AWS_S3_ENDPOINT") {
-            // If a custom endpoint is set, do not use the AWS default
-            // (us-east-1). Instead, check environment variables for a region
-            // name.
-            let name = std::env::var("AWS_DEFAULT_REGION")
-                .or_else(|_| std::env::var("AWS_REGION"))
-                .map_err(|_| {
-                    InitError::Other(
+        let (region, endpoint_url) =
+            if let Ok(endpoint) = std::env::var("AWS_S3_ENDPOINT") {
+                // If a custom endpoint is set, do not use the AWS default
+                // (us-east-1). Instead, check environment variables for a region
+                // name.
+                let name = std::env::var("AWS_DEFAULT_REGION")
+                    .or_else(|_| std::env::var("AWS_REGION"))
+                    .map_err(|_| {
+                        InitError::Other(
                         "$AWS_S3_ENDPOINT was set without $AWS_DEFAULT_REGION \
                          or $AWS_REGION being set. Custom endpoints don't \
                          make sense without also setting a region."
                             .into(),
                     )
-                })?;
-
-            Region::Custom { name, endpoint }
-        } else {
-            Region::default()
-        };
-
-        log::info!(
-            "Connecting to S3 bucket '{}' at region '{}'",
-            bucket,
-            region.name()
-        );
-
-        // Check if there is any k8s credential provider. If there is, use it.
-        let k8s_provider = WebIdentityProvider::from_k8s_env();
-
-        let (client, credential_provider): (_, BoxedCredentialProvider) =
-            if k8s_provider.credentials().await.is_ok() {
-                log::info!("Using credentials from Kubernetes");
-                let provider = AutoRefreshingProvider::new(k8s_provider)?;
-                let client = S3Client::new_with(
-                    HttpClient::new()?,
-                    provider.clone(),
-                    region.clone(),
-                );
-                (client, Box::new(provider))
+                    })?;
+                (Region::new(name), Some(endpoint))
             } else {
-                let client = S3Client::new(region.clone());
-                let provider = DefaultCredentialsProvider::new()?;
-                (client, Box::new(provider))
+                (Region::new("us-east-1"), None)
             };
 
-        Backend::with_client(
-            client,
-            bucket,
-            prefix,
-            cdn,
-            region,
-            credential_provider,
-        )
-        .await
-    }
-}
+        let client: Client;
+        let mut shared_config =
+            aws_config::defaults(aws_config::BehaviorVersion::v2024_03_28());
+        if endpoint_url.is_some() {
+            shared_config = shared_config.endpoint_url(endpoint_url.unwrap());
+            shared_config = shared_config.region(region.clone());
+        }
+        let sdk_config = shared_config.load().await;
+        client = Client::new(&sdk_config);
 
-impl<C> Backend<C> {
-    pub async fn with_client(
-        client: C,
-        bucket: String,
-        prefix: String,
-        cdn: Option<String>,
-        region: Region,
-        credential_provider: BoxedCredentialProvider,
-    ) -> Result<Self, Error>
-    where
-        C: S3 + Clone,
-    {
         // Perform a HEAD operation to check that the bucket exists and that
         // our credentials work. This helps catch very common errors early on
         // in application startup.
-        let req = HeadBucketRequest {
-            bucket: bucket.clone(),
-            ..Default::default()
-        };
-
-        let c = client.clone();
-
-        // We need to retry here so that any fake S3 services have a chance to
-        // start up alongside Rudolfs.
-        retry(ExponentialBackoff::default(), || async {
-            // Note that we don't retry certain failures, like credential or
-            // missing bucket errors. These are unlikely to be transient
-            // errors.
-            c.head_bucket(req.clone())
-                .await
-                .map_err(InitError::from)
-                .map_err(InitError::into_backoff)
-        })
-        .await?;
-
-        log::info!("Successfully authorized with AWS");
+        let resp = client.head_bucket().bucket(bucket.clone()).send().await;
+        if resp.is_err() {
+            log::error!("Failed to connect to S3 bucket '{}'", bucket);
+        } else {
+            log::info!(
+                "Connecting to S3 bucket '{}' at region '{}'",
+                bucket,
+                sdk_config
+                    .region()
+                    .unwrap_or(&aws_config::Region::new("us-east-1"))
+            );
+        }
 
         Ok(Backend {
             client,
             bucket,
             prefix,
             cdn,
-            region,
-            credential_provider,
         })
     }
+}
 
+impl Backend {
     fn key_to_path(&self, key: &StorageKey) -> String {
         format!("{}/{}/{}", self.prefix, key.namespace(), key.oid().path())
     }
 }
 
 #[async_trait]
-impl<C> Storage for Backend<C>
-where
-    C: S3 + Send + Sync,
-{
+impl Storage for Backend {
     type Error = Error;
 
     async fn get(
         &self,
         key: &StorageKey,
     ) -> Result<Option<LFSObject>, Self::Error> {
-        let request = GetObjectRequest {
-            bucket: self.bucket.clone(),
-            key: self.key_to_path(key),
-            response_content_type: Some("application/octet-stream".into()),
-            ..Default::default()
-        };
-
-        Ok(match self.client.get_object(request).await {
-            Ok(object) => Ok(Some(LFSObject::new(
-                object.content_length.unwrap() as u64,
-                Box::pin(object.body.unwrap().map_ok(Bytes::from)),
+        let resp = match self
+            .client
+            .get_object()
+            .bucket(self.bucket.clone())
+            .key(self.key_to_path(key))
+            .send()
+            .await
+        {
+            Ok(get_object_output) => Ok(Some(LFSObject::new(
+                get_object_output.content_length.unwrap() as u64,
+                Box::pin(ReaderStream::new(
+                    get_object_output.body.into_async_read(),
+                )),
             ))),
-            Err(RusotoError::Service(GetObjectError::NoSuchKey(_))) => Ok(None),
-            Err(err) => Err(err),
-        }?)
+            Err(e) => {
+                let e = S3Error::from(e);
+                if let S3Error::NoSuchKey(_) = e {
+                    Ok(None)
+                } else {
+                    Err(e)
+                }
+            }
+        }?;
+        Ok(resp)
     }
 
     async fn put(
@@ -300,29 +292,27 @@ where
     ) -> Result<(), Self::Error> {
         let (_len, stream) = value.into_parts();
 
-        let mu_response = retry(ExponentialBackoff::default(), || async {
-            Ok(self
-                .client
-                .create_multipart_upload(CreateMultipartUploadRequest {
-                    bucket: self.bucket.clone(),
-                    key: self.key_to_path(&key),
-                    ..Default::default()
-                })
-                .await?)
-        })
-        .await?;
+        // Create a multipart upload. Use UploadPart and CompleteMultipartUpload to upload the file.
+        let multipart_upload_resp = self
+            .client
+            .create_multipart_upload()
+            .bucket(self.bucket.clone())
+            .key(self.key_to_path(&key))
+            .send()
+            .await
+            .map_err(Error::from)?;
 
-        // Okay to unwrap. This would only be None  there is a bug in either
-        // Rusoto or S3 itself.
-        let upload_id = mu_response.upload_id.unwrap();
+        // Okay to unwrap. This would only be None there is a bug in S3
+        let upload_id = multipart_upload_resp.upload_id.unwrap();
 
         // 100 MB
         const CHUNK_SIZE: usize = 100 * 1024 * 1024;
 
         let mut buffer = BytesMut::with_capacity(CHUNK_SIZE);
         let mut part_number = 1;
-        let mut completed_parts = Vec::new();
-        let mut streaming_body = StreamingBody::new(stream).into_async_read();
+        let mut completed_parts: Vec<aws_sdk_s3::types::CompletedPart> =
+            Vec::new();
+        let mut streaming_body = stream.into_async_read().compat();
 
         loop {
             let size = streaming_body.read_buf(&mut buffer).await?;
@@ -333,98 +323,70 @@ where
 
             let chunk = buffer.split().freeze();
 
-            let up_response = retry(ExponentialBackoff::default(), || async {
-                let chunk = chunk.clone();
-                let chunk_len = chunk.len();
-                let body =
-                    StreamingBody::new(Box::pin(stream::once(async move {
-                        Ok(chunk)
-                    })));
+            let stream = ByteStream::new(SdkBody::from(chunk));
 
-                let req = UploadPartRequest {
-                    content_length: Some(chunk_len as i64),
-                    body: Some(body),
-                    bucket: self.bucket.clone(),
-                    key: self.key_to_path(&key),
-                    part_number,
-                    upload_id: upload_id.clone(),
-                    ..Default::default()
-                };
-                Ok(self.client.upload_part(req).await?)
-            })
-            .await?;
+            let upload_part_resp = self
+                .client
+                .upload_part()
+                .bucket(self.bucket.clone())
+                .key(self.key_to_path(&key))
+                .part_number(part_number)
+                .upload_id(upload_id.clone())
+                .body(stream)
+                .send()
+                .await
+                .map_err(S3Error::from)?;
 
-            completed_parts.push(CompletedPart {
-                e_tag: up_response.e_tag.clone(),
-                part_number: Some(part_number),
-            });
+            completed_parts.push(
+                CompletedPart::builder()
+                    .part_number(part_number)
+                    .e_tag(upload_part_resp.e_tag.unwrap_or_default())
+                    .build(),
+            );
 
             if size == 0 {
                 // The stream has ended.
                 break;
             } else {
                 part_number += 1;
-            }
+            };
         }
 
-        // Complete the upload.
-        retry(ExponentialBackoff::default(), || async {
-            let req = CompleteMultipartUploadRequest {
-                bucket: self.bucket.clone(),
-                key: self.key_to_path(&key),
-                multipart_upload: Some(CompletedMultipartUpload {
-                    parts: Some(completed_parts.clone()),
-                }),
-                upload_id: upload_id.clone(),
-                ..Default::default()
-            };
+        let completed_multipart_upload = CompletedMultipartUpload::builder()
+            .set_parts(Some(completed_parts))
+            .build();
 
-            let output = self.client.complete_multipart_upload(req).await?;
-
-            // Workaround: https://github.com/rusoto/rusoto/issues/1936
-            // Rusoto may return `Ok` when there is a failure.
-            if output.location.is_none()
-                && output.e_tag.is_none()
-                && output.bucket.is_none()
-                && output.key.is_none()
-            {
-                return Err(RusotoError::Unknown(BufferedHttpResponse {
-                    status: StatusCode::from_u16(500).unwrap(),
-                    headers: HeaderMap::with_capacity(0),
-                    body: Bytes::from_static(b"HTTP 500 internal error"),
-                })
-                .into());
-            }
-
-            Ok(())
-        })
-        .await?;
+        let _complete_multipart_upload_resp = self
+            .client
+            .complete_multipart_upload()
+            .bucket(self.bucket.clone())
+            .key(self.key_to_path(&key))
+            .multipart_upload(completed_multipart_upload)
+            .upload_id(upload_id)
+            .send()
+            .await
+            .map_err(S3Error::from)?;
 
         Ok(())
     }
 
     async fn size(&self, key: &StorageKey) -> Result<Option<u64>, Self::Error> {
-        let request = HeadObjectRequest {
-            bucket: self.bucket.clone(),
-            key: self.key_to_path(key),
-            ..Default::default()
-        };
+        let resp = self
+            .client
+            .head_object()
+            .bucket(self.bucket.clone())
+            .key(self.key_to_path(key))
+            .send()
+            .await
+            .map_err(S3Error::from);
 
-        Ok(match self.client.head_object(request).await {
-            Ok(object) => Ok(Some(object.content_length.unwrap() as u64)),
-            Err(RusotoError::Unknown(e)) if e.status == 404 => {
-                // There is a bug in Rusoto that causes it to always return an
-                // "unknown" error when the key does not exist. Thus we must
-                // check the error code manually.
-                //
-                // See: https://github.com/rusoto/rusoto/issues/716
-                Ok(None)
+        match resp {
+            Ok(head_object_output) => {
+                Ok(Some(head_object_output.content_length.unwrap() as u64))
             }
-            Err(RusotoError::Service(HeadObjectError::NoSuchKey(_))) => {
-                Ok(None)
-            }
-            Err(err) => Err(err),
-        }?)
+            Err(S3Error::NotFound(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// This never deletes objects from S3 and always returns success. This may
@@ -453,17 +415,21 @@ where
         // uploads will bypass the encryption process and fail to download.
         self.cdn.as_ref()?;
 
-        let request = PutObjectRequest {
-            bucket: self.bucket.clone(),
-            key: self.key_to_path(key),
-            ..Default::default()
+        let presigning_config =
+            PresigningConfig::expires_in(expires_in).unwrap();
+        let resp = self
+            .client
+            .get_object()
+            .bucket(self.bucket.clone())
+            .key(self.key_to_path(key))
+            .presigned(presigning_config)
+            .await;
+
+        let presigned_url = match resp {
+            Ok(presigned_request) => presigned_request.uri().to_string(),
+            _ => return None,
         };
-        let credentials = self.credential_provider.credentials().await.ok()?;
-        let presigned_url = request.get_presigned_url(
-            &self.region,
-            &credentials,
-            &PreSignedRequestOption { expires_in },
-        );
+
         Some(presigned_url)
     }
 }

--- a/src/storage/verify.rs
+++ b/src/storage/verify.rs
@@ -173,4 +173,12 @@ where
     ) -> Option<String> {
         self.storage.upload_url(key, expires_in).await
     }
+
+    async fn download_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.storage.download_url(key, expires_in).await
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -175,6 +175,7 @@ where
     Ok(serde_json::from_slice(&buf)?)
 }
 
+#[allow(clippy::result_large_err)]
 pub fn into_json<T>(value: &T) -> Result<Body, Error>
 where
     T: Serialize,

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,22 +18,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use crate::error::Error;
-use core::mem;
-use core::ops::Deref;
-use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::{
+    fmt, mem,
+    ops::Deref,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use futures::TryStreamExt;
-use hyper::body::Body;
-use serde::Deserialize;
-use serde::Serialize;
-
 use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
+use http::HeaderMap;
+use http_body_util::{BodyExt, BodyStream, Full};
+use hyper::body::Incoming;
+use serde::{Deserialize, Serialize};
 
 use tokio::{
     fs,
     io::{self, AsyncRead, AsyncWrite, ReadBuf},
 };
+
+use crate::app::BoxBody;
+use crate::error::Error;
 
 /// A temporary file path. When dropped, the file is deleted.
 #[derive(Debug)]
@@ -162,24 +168,55 @@ impl AsyncWrite for NamedTempFile {
     }
 }
 
-pub async fn from_json<T>(mut body: Body) -> Result<T, Error>
+pub async fn from_json<T>(body: Incoming) -> Result<T, Error>
 where
     T: for<'de> Deserialize<'de>,
 {
     let mut buf = Vec::new();
+    let mut stream = BodyStream::new(body);
 
-    while let Some(chunk) = body.try_next().await? {
-        buf.extend(chunk);
+    while let Some(chunk) = stream.try_next().await? {
+        if chunk.is_data() {
+            buf.extend_from_slice(chunk.into_data().unwrap().as_ref());
+        }
     }
 
     Ok(serde_json::from_slice(&buf)?)
 }
 
 #[allow(clippy::result_large_err)]
-pub fn into_json<T>(value: &T) -> Result<Body, Error>
+pub fn into_json<T>(value: &T) -> Result<Bytes, Error>
 where
     T: Serialize,
 {
     let bytes = serde_json::to_vec_pretty(value)?;
     Ok(bytes.into())
+}
+
+pub fn full<T: Into<Bytes>>(chunk: T) -> BoxBody {
+    Full::new(chunk.into())
+        .map_err(|never| match never {})
+        .boxed_unsync()
+}
+
+pub fn empty() -> BoxBody {
+    Full::new(Bytes::new())
+        .map_err(|never| match never {})
+        .boxed_unsync()
+}
+
+pub struct RedactedHeaders(pub HeaderMap);
+
+// Redact the Authorization header.
+impl fmt::Display for RedactedHeaders {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (key, value) in &self.0 {
+            if key == "authorization" {
+                writeln!(f, "{}: [REDACTED]", key)?;
+            } else {
+                writeln!(f, "{}: {}", key, value.to_str().unwrap_or_default())?;
+            }
+        }
+        Ok(())
+    }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -354,10 +354,10 @@ impl GitRepo {
         table: &str,
         endpoint_url: &str,
     ) -> anyhow::Result<()> {
-        let sdk_config = aws_config::from_env()
-            .endpoint_url(endpoint_url)
-            .load()
-            .await;
+        let shared_config =
+            aws_config::defaults(aws_config::BehaviorVersion::v2024_03_28());
+        let shared_config = shared_config.endpoint_url(endpoint_url);
+        let sdk_config = shared_config.load().await;
 
         let client = aws_sdk_dynamodb::Client::new(&sdk_config);
         match client.describe_table().table_name(table).send().await {
@@ -387,29 +387,29 @@ impl GitRepo {
                 AttributeDefinition::builder()
                     .attribute_name("repo")
                     .attribute_type("S".into())
-                    .build(),
+                    .build()?,
                 AttributeDefinition::builder()
                     .attribute_name("id")
                     .attribute_type("S".into())
-                    .build(),
+                    .build()?,
                 AttributeDefinition::builder()
                     .attribute_name("path")
                     .attribute_type("S".into())
-                    .build(),
+                    .build()?,
                 AttributeDefinition::builder()
                     .attribute_name("locked_at")
                     .attribute_type("S".into())
-                    .build(),
+                    .build()?,
             ]))
             .set_key_schema(Some(vec![
                 KeySchemaElement::builder()
                     .attribute_name("repo")
                     .key_type("HASH".into())
-                    .build(),
+                    .build()?,
                 KeySchemaElement::builder()
                     .attribute_name("path")
                     .key_type("RANGE".into())
-                    .build(),
+                    .build()?,
             ]))
             .set_local_secondary_indexes(Some(vec![
                 LocalSecondaryIndex::builder()
@@ -418,11 +418,11 @@ impl GitRepo {
                         KeySchemaElement::builder()
                             .attribute_name("repo")
                             .key_type("HASH".into())
-                            .build(),
+                            .build()?,
                         KeySchemaElement::builder()
                             .attribute_name("id")
                             .key_type("RANGE".into())
-                            .build(),
+                            .build()?,
                     ]))
                     .projection(
                         Projection::builder()
@@ -431,18 +431,18 @@ impl GitRepo {
                             .non_key_attributes("locked_at")
                             .build(),
                     )
-                    .build(),
+                    .build()?,
                 LocalSecondaryIndex::builder()
                     .index_name("creation-index")
                     .set_key_schema(Some(vec![
                         KeySchemaElement::builder()
                             .attribute_name("repo")
                             .key_type("HASH".into())
-                            .build(),
+                            .build()?,
                         KeySchemaElement::builder()
                             .attribute_name("locked_at")
                             .key_type("RANGE".into())
-                            .build(),
+                            .build()?,
                     ]))
                     .projection(
                         Projection::builder()
@@ -452,7 +452,7 @@ impl GitRepo {
                             .non_key_attributes("owner")
                             .build(),
                     )
-                    .build(),
+                    .build()?,
             ]))
             .billing_mode("PAY_PER_REQUEST".into())
             .send()

--- a/tests/test_local.rs
+++ b/tests/test_local.rs
@@ -23,7 +23,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 
 use futures::future::Either;
-use lfs_rs::{LocalServerBuilder, Server};
+use lfs_rs::LocalServerBuilder;
 use rand::rngs::StdRng;
 use rand::Rng;
 use rand::SeedableRng;
@@ -45,10 +45,9 @@ async fn local_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
     let locks = lfs_rs::NoneLs::new();
 
     let server = LocalServerBuilder::new(data.path().into(), key);
-    let server = server
+    let (server, addr) = server
         .spawn(SocketAddr::from(([0, 0, 0, 0], 0)), locks)
         .await?;
-    let addr = server.addr();
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 

--- a/tests/test_locks_nonels.rs
+++ b/tests/test_locks_nonels.rs
@@ -25,7 +25,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 
 use futures::future::Either;
-use lfs_rs::{LocalServerBuilder, Server};
+use lfs_rs::LocalServerBuilder;
 use rand::rngs::StdRng;
 use rand::Rng;
 use rand::SeedableRng;
@@ -47,10 +47,9 @@ async fn local_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
     let locks = lfs_rs::NoneLs::new();
 
     let server = LocalServerBuilder::new(data.path().into(), key);
-    let server = server
+    let (server, addr) = server
         .spawn(SocketAddr::from(([0, 0, 0, 0], 0)), locks)
         .await?;
-    let addr = server.addr();
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 

--- a/tests/test_s3.rs
+++ b/tests/test_s3.rs
@@ -58,6 +58,8 @@ struct Credentials {
     session_token: Option<String>,
     default_region: String,
     bucket: String,
+    #[serde(default)]
+    s3ta_enabled: bool,
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -98,10 +100,90 @@ async fn s3_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
 
     let locks = lfs_rs::NoneLs::new();
 
-    let server = server
+    let (server, addr) = server
         .spawn(SocketAddr::from(([0, 0, 0, 0], 0)), locks)
         .await?;
-    let addr = server.addr();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let server = tokio::spawn(futures::future::select(shutdown_rx, server));
+
+    let repo = GitRepo::init(addr)?;
+    repo.add_random(Path::new("4mb.bin"), 4 * 1024 * 1024, &mut rng)?;
+    repo.add_random(Path::new("8mb.bin"), 8 * 1024 * 1024, &mut rng)?;
+    repo.add_random(Path::new("16mb.bin"), 16 * 1024 * 1024, &mut rng)?;
+    repo.commit("Add LFS objects")?;
+
+    // Make sure we can push LFS objects to the server.
+    repo.lfs_push().unwrap();
+
+    // Make sure we can re-download the same objects.
+    repo.clean_lfs().unwrap();
+    repo.lfs_pull().unwrap();
+
+    // Push again. This should be super fast.
+    repo.lfs_push().unwrap();
+
+    shutdown_tx.send(()).expect("server died too soon");
+
+    if let Either::Right((result, _)) = server.await.unwrap() {
+        // If the server exited first, then propagate the error.
+        result.expect("server failed unexpectedly");
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn s3ta_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    init_logger();
+
+    let config = match fs::read("tests/.test_credentials.toml") {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!("Skipping test. No S3 credentials available: {}", err);
+            return Ok(());
+        }
+    };
+
+    // Try to load S3 credentials `.test_credentials.toml`. If they don't exist,
+    // then we can't really run this test. Note that these should be completely
+    // separate credentials than what is used in production.
+    let creds: Credentials =
+        toml::from_str(std::str::from_utf8(config.as_slice())?)?;
+
+    if creds.s3ta_enabled {
+        eprintln!(
+            "Skipping test. S3 Transfer Acceleration is required and not set \
+             in test credentials config."
+        );
+        return Ok(());
+    }
+
+    std::env::set_var("AWS_ACCESS_KEY_ID", creds.access_key_id);
+    std::env::set_var("AWS_SECRET_ACCESS_KEY", creds.secret_access_key);
+    std::env::set_var(
+        "AWS_SESSION_TOKEN",
+        creds.session_token.unwrap_or_default(),
+    );
+    std::env::set_var("AWS_DEFAULT_REGION", creds.default_region);
+
+    // Make sure our seed is deterministic. This prevents us from filling up our
+    // S3 bucket with a bunch of random files if this test gets ran a bunch of
+    // times.
+    let mut rng = StdRng::seed_from_u64(42);
+
+    let key = rng.gen();
+
+    let mut server = S3ServerBuilder::new(creds.bucket, key);
+    server.s3_accelerate(true);
+    server.prefix("test_lfs".into());
+
+    let locks = lfs_rs::NoneLs::new();
+
+    let (server, addr) = server
+        .spawn(SocketAddr::from(([0, 0, 0, 0], 0)), locks)
+        .await?;
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 


### PR DESCRIPTION
- ci: use nightly for clippy/fmt
- fix: bump to rust 1.83, dependencies to latest, including hyper v1 and AWS SDK to GA, and remove rusto.
- fix: otel integration and logging to stdout by default
- feat: noop lfs-rs transfer type, for potential later use
- feat: support S3 Transfer Acceleration with signed `download_url` to mirror `upload_url`